### PR TITLE
SSL params bug fixes and improvements

### DIFF
--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -26,6 +26,12 @@ class BaseConnection(Publisher):
     def is_connected(self):
         return self.transport.is_connected()
 
+    def set_ssl(self, *args, **kwargs):
+        self.transport.set_ssl(*args, **kwargs)
+
+    def get_ssl(self, *args, **kwargs):
+        self.transport.get_ssl(*args, **kwargs)
+
 
 class StompConnection10(BaseConnection, Protocol10):
     """

--- a/stomp/test/ssl_test.py
+++ b/stomp/test/ssl_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import stomp
 from stomp import transport
 
 from testutils import *
@@ -15,7 +16,7 @@ class TestSSL(unittest.TestCase):
             import ssl
             queuename = '/queue/test4-%s' % self.timestamp
             conn = stomp.Connection(get_standard_ssl_host())
-            conn.set_ssl([get_standard_ssl_host()])
+            conn.set_ssl(get_standard_ssl_host())
             conn.set_listener('', self.listener)
             conn.start()
             conn.connect('admin', 'password', wait=True)
@@ -26,10 +27,10 @@ class TestSSL(unittest.TestCase):
             self.listener.wait_on_receipt()
             conn.disconnect()
 
-            self.assert_(self.listener.connections > 1, 'should have received 1 connection acknowledgement')
+            self.assert_(self.listener.connections == 1, 'should have received 1 connection acknowledgement')
             self.assert_(self.listener.messages == 1, 'should have received 1 message')
             self.assert_(self.listener.errors == 0, 'should not have received any errors')
-        except:
+        except ImportError:
             pass
 
 

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -643,10 +643,10 @@ class Transport(listener.Publisher):
                     log.debug("Attempting connection to host %s, port %s" % host_and_port)
                     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     self.__enable_keepalive()
-                    ssl = self.__need_ssl(host_and_port)
+                    need_ssl = self.__need_ssl(host_and_port)
 
-                    if ssl:  # wrap socket
-                        ssl_params = self.get_ssl()
+                    if need_ssl:  # wrap socket
+                        ssl_params = self.get_ssl(host_and_port)
                         if ssl_params['ca_certs']:
                             cert_validation = ssl.CERT_REQUIRED
                         else:
@@ -666,7 +666,7 @@ class Transport(listener.Publisher):
                     #
                     # Validate server cert
                     #
-                    if ssl and ssl_params['cert_validator']: 
+                    if need_ssl and ssl_params['cert_validator']:
                         cert = self.socket.getpeercert()
                         (ok, errmsg) = apply(ssl_params['cert_validator'], (cert, host_and_port[0]))
                         if not ok:


### PR DESCRIPTION
Pull request #6 broke SSL connections:
- get_ssl while connecting should receive the host and port we are
  trying to connect to, since current_host_and_port may not be set yet.
- local variable ssl redefines ssl module, shadowing it
- SSL connection test fails, however there's an except block catching
  all errors and test pass even if it shouldn't.
- Expose set_ssl/get_ssl methods to connection objects
