### PR TITLE
Don't attempt to parse message payloads as UTF-8.

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -14,10 +14,7 @@ import warnings
 # STOMP protocol
 
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 try:
     import ssl
@@ -63,7 +60,7 @@ class BaseTransport(listener.Publisher):
             (block) for the server to respond with that receipt-id
             before continuing
         """
-        self.__recvbuf = ''
+        self.__recvbuf = b''
         self.listeners = {}
         self.running = False
         self.blocking = None
@@ -320,7 +317,7 @@ class BaseTransport(listener.Publisher):
         """
         Read the next frame(s) from the socket.
         """
-        fastbuf = StringIO()
+        fastbuf = BytesIO()
         while self.running:
             try:
                 try:
@@ -328,16 +325,15 @@ class BaseTransport(listener.Publisher):
                 except InterruptedException:
                     log.debug("socket read interrupted, restarting")
                     continue
-                c = decode(c)
             except Exception:
                 _, e, _ = sys.exc_info()
                 c = ''
             if len(c) == 0:
                 raise exception.ConnectionClosedException()
             fastbuf.write(c)
-            if '\x00' in c:
+            if b'\x00' in c:
                 break
-            elif c == '\x0a':
+            elif c == b'\x0a':
                 # heartbeat (special case)
                 return c
         self.__recvbuf += fastbuf.getvalue()
@@ -346,13 +342,13 @@ class BaseTransport(listener.Publisher):
 
         if len(self.__recvbuf) > 0 and self.running:
             while True:
-                pos = self.__recvbuf.find('\x00')
+                pos = self.__recvbuf.find(b'\x00')
 
                 if pos >= 0:
                     frame = self.__recvbuf[0:pos]
-                    preamble_end = frame.find('\n\n')
+                    preamble_end = frame.find(b'\n\n')
                     if preamble_end >= 0:
-                        content_length_match = Transport.__content_length_re.search(frame[0:preamble_end])
+                        content_length_match = Transport.__content_length_re.search(decode(frame[0:preamble_end]))
                         if content_length_match:
                             content_length = int(content_length_match.group('value'))
                             content_offset = preamble_end + 2

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -327,7 +327,7 @@ class BaseTransport(listener.Publisher):
                     continue
             except Exception:
                 _, e, _ = sys.exc_info()
-                c = ''
+                c = b''
             if len(c) == 0:
                 raise exception.ConnectionClosedException()
             fastbuf.write(c)
@@ -335,7 +335,7 @@ class BaseTransport(listener.Publisher):
                 break
             elif c == b'\x0a':
                 # heartbeat (special case)
-                return c
+                return [c,]
         self.__recvbuf += fastbuf.getvalue()
         fastbuf.close()
         result = []

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -108,7 +108,7 @@ def parse_frame(frame):
         the frame received from the server (as a string)
     """
     f = Frame()
-    if frame == '\x0a':
+    if frame == b'\x0a':
         f.cmd = 'heartbeat'
         return f
         

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import md5 as hashlib
 
-from stomp.backward import NULL
+from stomp.backward import NULL, decode
 
 ##@namespace stomp.utils
 # General utilities.
@@ -42,7 +42,7 @@ HEADER_LINE_RE = re.compile('(?P<key>[^:]+)[:](?P<value>.*)')
 ##
 # As of STOMP 1.2, lines can end with either line feed, or carriage return plus line feed. 
 #
-PREAMBLE_END_RE = re.compile('\n\n|\r\n\r\n')
+PREAMBLE_END_RE = re.compile(b'\n\n|\r\n\r\n')
 
 ##
 # As of STOMP 1.2, lines can end with either line feed, or carriage return plus line feed. 
@@ -118,7 +118,7 @@ def parse_frame(frame):
         preamble_end = mat.start()
     if preamble_end == -1:
         preamble_end = len(frame)
-    preamble = frame[0:preamble_end]
+    preamble = decode(frame[0:preamble_end])
     preamble_lines = LINE_END_RE.split(preamble)
     f.body = frame[preamble_end + 2:]
 


### PR DESCRIPTION
STOMP messages can legitimately be binary, which fails to decode
as UTF-8. On python 2, no decoding is attempted, but on python 3
the code attempts to decode the entire frame as UTF-8, which fails
if the binary data contains invalid UTF-8 sequences.

This PR is tested on python 2.7 and 3.4 and works fine. However, on python 3 it changes the message body that is returned from being a string to a bytes. This is necessary because otherwise there's no way of getting a binary message payload out of the library. However it's not backwards compatible with existing users of the library on python 3 who expect a string for the message payload. I'm not sure what is the best way of dealing with this.

Perhaps we need a flag passed to the Stomp object (or perhaps on subscribing to a channel, since different channels can contain different types of data) which sets the behaviour as assuming UTF-8 or assuming binary, and default to UTF-8 on python 3 to match the current behaviour?