### PR TITLE
Avoid AttributeError in CLI when connecting fails due to wrong authentication

### DIFF
--- a/stomp/__main__.py
+++ b/stomp/__main__.py
@@ -48,6 +48,7 @@ class StompCLI(Cmd, ConnectionListener):
         self.verbose = verbose
         self.user = user
         self.passcode = passcode
+        self.__quit = False
         if ver == '1.0':
             self.conn = StompConnection10([(host, port)], wait_on_receipt=True)
         elif ver == '1.1':
@@ -65,7 +66,6 @@ class StompCLI(Cmd, ConnectionListener):
         self.version = ver
         self.__subscriptions = {}
         self.__subscription_id = 1
-        self.__quit = False
 
     def __print_async(self, frame_type, headers, body):
         """


### PR DESCRIPTION
<pre>
> Exception in thread Thread-1:
[...]
  File "[...]/stomp/__main__.py", line 102, in on_disconnected
    if not self.__quit:
AttributeError: 'StompCLI' object has no attribute '_StompCLI__quit'
</pre>