### PR TITLE
Invoke sys.executable in preference to "python" in CLI

### DIFF
--- a/scripts/stomp
+++ b/scripts/stomp
@@ -5,5 +5,6 @@ import stomp
 import sys
 
 stomp_path = os.path.dirname(stomp.__file__)
+executable = sys.executable or "python"
 
-os.system('python %s %s' % (stomp_path, ' '.join(sys.argv)))
+os.system('%s %s %s' % (executable, stomp_path, ' '.join(sys.argv)))


### PR DESCRIPTION
...so that for example "python3 /path/to/stomp" runs ends up running python3.