### PR TITLE
Allow setup.py to run without coverage installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 from distutils.core import setup, Command
 
-import coverage
 import unittest
 
 import logging.config
@@ -23,6 +22,7 @@ class TestCommand(Command):
         pass
 
     def run(self):
+        import coverage
         cov = coverage.coverage()
         cov.start()
         


### PR DESCRIPTION
Avoids an error with pip install. I guess with setuptools one could additionally add <code>tests_require = ['coverage']</code> to <code>setup()</code> but that option doesn't seem to be available for distutils.