### PR TITLE
Do not try to decode nonexistent message bodies

### DIFF
--- a/stomp/backward3.py
+++ b/stomp/backward3.py
@@ -12,6 +12,8 @@ def input_prompt(prompt):
 
 
 def decode(byte_data):
+    if byte_data is None:
+        return None
     return byte_data.decode('utf-8')
 
 

--- a/stomp/test/p3_nonascii_test.py
+++ b/stomp/test/p3_nonascii_test.py
@@ -89,3 +89,19 @@ class TestNonAsciiSendAutoEncoding(unittest.TestCase):
 
         (headers, msg) = self.listener.get_latest_message()
         self.assertEquals(txt, msg)
+
+    def test_send_none_auto_encoding(self):
+        queuename = '/queue/p3nonasciitest2-%s' % self.timestamp
+        self.conn.subscribe(destination=queuename, ack='auto', id='1')
+
+        txt = None
+        self.conn.send(body=txt, destination=queuename, receipt='123')
+
+        self.listener.wait_on_receipt()
+
+        self.assert_(self.listener.connections >= 1, 'should have received 1 connection acknowledgement')
+        self.assert_(self.listener.messages >= 1, 'should have received 1 message')
+        self.assert_(self.listener.errors == 0, 'should not have received any errors')
+
+        (headers, msg) = self.listener.get_latest_message()
+        self.assertEquals(txt, msg)


### PR DESCRIPTION
The test case is untested as I don't have the setup required for running the suite right now.