### PR TITLE
Auto-send content-length when message body is present

### DIFF
--- a/stomp/backward2.py
+++ b/stomp/backward2.py
@@ -21,10 +21,6 @@ def encode(char_data):
         return char_data
 
 
-def hasbyte(byte, byte_data):
-    return chr(byte) in byte_data
-
-
 def pack(pieces):
     return ''.join(pieces)
 

--- a/stomp/backward3.py
+++ b/stomp/backward3.py
@@ -26,11 +26,6 @@ def encode(char_data):
         raise TypeError('message should be a string or bytes')
 
 
-def hasbyte(byte, byte_data):
-    assert type(byte) is int and 0 <= byte and byte < 2**8
-    return bytes([byte]) in byte_data
-
-
 def pack(pieces):
     encoded_pieces = (encode(piece) for piece in pieces)
     return b''.join(encoded_pieces)

--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -2,7 +2,7 @@ import uuid
 
 from stomp.exception import ConnectFailedException
 from stomp.listener import *
-from stomp.backward import encode, hasbyte
+from stomp.backward import encode
 from stomp.constants import *
 import stomp.utils as utils
 
@@ -83,8 +83,8 @@ class Protocol10(ConnectionListener):
         if content_type:
             headers[HDR_CONTENT_TYPE] = content_type
         body = encode(body)
-        #if HDR_CONTENT_LENGTH not in headers:
-        #    headers[HDR_CONTENT_LENGTH] = len(body)
+        if body and HDR_CONTENT_LENGTH not in headers:
+            headers[HDR_CONTENT_LENGTH] = len(body)
         self.send_frame(CMD_SEND, headers, body)
 
     def subscribe(self, destination, id=None, ack='auto', headers={}, **keyword_headers):
@@ -200,7 +200,7 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         if content_type:
             headers[HDR_CONTENT_TYPE] = content_type
         body = encode(body)
-        if HDR_CONTENT_LENGTH not in headers and hasbyte(0, body):
+        if body and HDR_CONTENT_LENGTH not in headers:
             headers[HDR_CONTENT_LENGTH] = len(body)
         self.send_frame(CMD_SEND, headers, body)
 


### PR DESCRIPTION
For all protocol versions, sending content-length is recommended by the specs when a body is present, not only when it contains the null byte.

This essentially reverts commit a8d103eec5041fdc29fd7260c9c6ffd1b5649d77 which mentions it fixes content length header handling, but I don't see anything wrong with it apart from that it probably sent it also for empty message bodies and there's no further info in the commit message or change log.