### PR TITLE
Fix SSL Attribute Error on newer builds of Python.

### DIFF
--- a/stomp/__init__.py
+++ b/stomp/__init__.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.split(__file__)[0])
 
 import connect, listener, exception
 
-__version__ = (3, 1, 6)
+__version__ = (3, 1, 7)
 Connection = connect.Connection
 ConnectionListener = listener.ConnectionListener
 StatsListener = listener.StatsListener

--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -8,21 +8,40 @@ import time
 import types
 import xml.dom.minidom
 import errno
+import logging
 
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 
+log = logging.getLogger('stomp.py')
+
+protocols = frozenset([
+    'PROTOCOL_SSLv3',
+    'PROTOCOL_TLSv1_2',
+    'PROTOCOL_TLSv1_1',
+    'PROTOCOL_TLSv1',
+    'PROTOCOL_SSLv23',
+    'PROTOCOL_SSLv2',
+
+])
+DEFAULT_SSL_VERSION = None
+SSL_AVAILABLE = True
 try:
     import ssl
     from ssl import SSLError
-    DEFAULT_SSL_VERSION = ssl.PROTOCOL_SSLv3
-except ImportError: # python version < 2.6 without the backported ssl module
-    ssl = None
-    class SSLError:
-        pass
-    DEFAULT_SSL_VERSION = None
+except ImportError:
+    SSL_AVAILABLE = False
+
+if SSL_AVAILABLE:
+    for protocol in protocols:
+        try:
+            DEFAULT_SSL_VERSION = getattr(ssl, protocol)
+        except (AttributeError, SSLError):
+            continue
+        log.debug("Set DEFAULT_SSL_VERSION: '{0}'".format(protocol))
+        break
 
 try:
     from socket import SOL_SOCKET, SO_KEEPALIVE
@@ -37,7 +56,7 @@ import utils
 from backward import decode, encode, hasbyte, pack, socksend, NULL
 
 try:
-    import uuid    
+    import uuid
 except ImportError:
     from backward import uuid
 
@@ -45,9 +64,6 @@ try:
     from fractions import gcd
 except ImportError:
     from backward import gcd
-
-import logging
-log = logging.getLogger('stomp.py')
 
 class Connection(object):
     """
@@ -61,29 +77,29 @@ class Connection(object):
     # and external interfaces).  This is used for determining
     # preferred targets.
     __localhost_names = [ "localhost", "127.0.0.1" ]
-    
+
     try:
         __localhost_names.append(socket.gethostbyname(socket.gethostname()))
     except:
         pass
-        
+
     try:
         __localhost_names.append(socket.gethostname())
     except:
         pass
-        
+
     try:
         __localhost_names.append(socket.getfqdn(socket.gethostname()))
     except:
         pass
-    
+
     #
     # Used to parse the STOMP "content-length" header lines,
     #
     __content_length_re = re.compile('^content-length[:]\\s*(?P<value>[0-9]+)', re.MULTILINE)
 
-    def __init__(self, 
-                 host_and_ports = [ ('localhost', 61613) ], 
+    def __init__(self,
+                 host_and_ports = [ ('localhost', 61613) ],
                  user = None,
                  passcode = None,
                  prefer_localhost = True,
@@ -110,24 +126,24 @@ class Connection(object):
         """
         Initialize and start this connection.
 
-        \param host_and_ports            
+        \param host_and_ports
             a list of (host, port) tuples.
 
         \param prefer_localhost
             if True and the local host is mentioned in the (host,
             port) tuples, try to connect to this first
 
-        \param try_loopback_connect    
+        \param try_loopback_connect
             if True and the local host is found in the host
             tuples, try connecting to it using loopback interface
             (127.0.0.1)
 
-        \param reconnect_sleep_initial 
+        \param reconnect_sleep_initial
             initial delay in seconds to wait before reattempting
             to establish a connection if connection to any of the
             hosts fails.
 
-        \param reconnect_sleep_increase 
+        \param reconnect_sleep_increase
             factor by which the sleep delay is increased after
             each connection attempt. For example, 0.5 means
             to wait 50% longer than before the previous attempt,
@@ -145,18 +161,18 @@ class Connection(object):
             stampeding. For example, a value of 0.1 means to wait
             an extra 0%-10% (randomly determined) of the delay
             calculated using the previous three parameters.
-                 
+
         \param reconnect_attempts_max
             maximum attempts to reconnect
-                
+
         \param use_ssl
-            connect using SSL to the socket.  This wraps the 
-            socket in a SSL connection.  The constructor will 
+            connect using SSL to the socket.  This wraps the
+            socket in a SSL connection.  The constructor will
             raise an exception if you ask for SSL, but it can't
             find the SSL module.
 
         \param ssl_cert_file
-            the path to a X509 certificate 
+            the path to a X509 certificate
 
         \param ssl_key_file
             the path to a X509 key file
@@ -164,7 +180,7 @@ class Connection(object):
         \param ssl_ca_certs
             the path to the a file containing CA certificates
             to validate the server against.  If this is not set,
-            server side certificate validation is not done. 
+            server side certificate validation is not done.
 
         \param ssl_cert_validator
             function which performs extra validation on the client
@@ -175,30 +191,30 @@ class Connection(object):
                 (OK, err_msg) = validation_function(cert, hostname)
             where OK is a boolean, and cert is a certificate structure
             as returned by ssl.SSLSocket.getpeercert()
-            
+
         \param wait_on_receipt
             if a receipt is specified, then the send method should wait
             (block) for the server to respond with that receipt-id
             before continuing
-            
+
         \param ssl_version
             SSL protocol to use for the connection. This should be
             one of the PROTOCOL_x constants provided by the ssl module.
             The default is ssl.PROTOCOL_SSLv3
-            
+
         \param timeout
             the timeout value to use when connecting the stomp socket
-            
+
         \param version
             STOMP protocol version (1.0 or 1.1)
-            
+
         \param strict
             if true, use the strict version of the protocol. For STOMP 1.1, this means
             it will use the STOMP connect header, rather than CONNECT.
-            
+
         \param heartbeats
             a tuple containing the heartbeat send and receive time in millis. (0,0)
-            if no heartbeats 
+            if no heartbeats
 
         \param keepalive
             some operating systems support sending the occasional heart
@@ -229,7 +245,7 @@ class Connection(object):
             for host_and_port in sorted_host_and_ports:
                 if self.is_localhost(host_and_port) == 1:
                     port = host_and_port[1]
-                    if (not ("127.0.0.1", port) in sorted_host_and_ports 
+                    if (not ("127.0.0.1", port) in sorted_host_and_ports
                         and not ("localhost", port) in sorted_host_and_ports):
                         loopback_host_and_ports.append(("127.0.0.1", port))
 
@@ -250,7 +266,7 @@ class Connection(object):
         self.__reconnect_sleep_max = reconnect_sleep_max
         self.__reconnect_attempts_max = reconnect_attempts_max
         self.__timeout = timeout
-        
+
         self.__connect_headers = {}
         if user is not None and passcode is not None:
             self.__connect_headers['login'] = user
@@ -264,10 +280,10 @@ class Connection(object):
         self.__receiver_thread_exited = False
         self.__send_wait_condition = threading.Condition()
         self.__connect_wait_condition = threading.Condition()
-        
+
         self.blocking = None
         self.connected = False
-        
+
         # setup SSL
         if use_ssl and not ssl:
             raise Exception("SSL connection requested, but SSL library not found.")
@@ -277,25 +293,25 @@ class Connection(object):
         self.__ssl_ca_certs = ssl_ca_certs
         self.__ssl_cert_validator = ssl_cert_validator
         self.__ssl_version = ssl_version
-        
+
         self.__receipts = {}
         self.__wait_on_receipt = wait_on_receipt
-        
+
         # protocol version
         self.version = version
         self.__strict = strict
 
         # setup heartbeating
         if version < 1.1 and heartbeats != (0, 0):
-            raise exception.ProtocolException('Heartbeats can only be set on a 1.1+ connection')            
+            raise exception.ProtocolException('Heartbeats can only be set on a 1.1+ connection')
         self.heartbeats = heartbeats
-        
+
         # used for 1.1 heartbeat messages (set to true every time a heartbeat message arrives)
         self.__received_heartbeat = time.time()
-        
+
         # flag used when we receive the disconnect receipt
         self.__disconnect_receipt = None
-        
+
         # function for creating threads used by the connection
         self.create_thread_fc = default_create_thread
 
@@ -311,7 +327,7 @@ class Connection(object):
             return 1
         else:
             return 2
-            
+
     def override_threading(self, create_thread_fc):
         """
         Override for thread creation. Use an alternate threading library by
@@ -355,7 +371,7 @@ class Connection(object):
         connection.
         """
         return self.__current_host_and_port
-        
+
     def is_connected(self):
         """
         Return true if the socket managed by this connection is connected
@@ -364,7 +380,7 @@ class Connection(object):
             return self.__socket is not None and self.__socket.getsockname()[1] != 0 and self.connected
         except socket.error:
             return False
-        
+
     #
     # Manage objects listening to incoming frames
     #
@@ -372,18 +388,18 @@ class Connection(object):
     def set_listener(self, name, listener):
         """
         Set a named listener on this connection
-        
+
         \see listener::ConnectionListener
-        
+
         \param name the name of the listener
         \param listener the listener object
         """
         self.__listeners[name] = listener
-        
+
     def remove_listener(self, name):
         """
         Remove a listener according to the specified name
-        
+
         \param name the name of the listener to remove
         """
         del self.__listeners[name]
@@ -391,7 +407,7 @@ class Connection(object):
     def get_listener(self, name):
         """
         Return a named listener
-        
+
         \param name the listener to return
         """
         if name in self.__listeners:
@@ -419,7 +435,7 @@ class Connection(object):
         """
         merged_headers = utils.merge_headers([headers, keyword_headers])
         self.__send_frame_helper('UNSUBSCRIBE', '', merged_headers, [ ('destination', 'id') ])
-        
+
     def send(self, message='', headers={}, **keyword_headers):
         """
         Send a message (SEND) frame
@@ -428,11 +444,11 @@ class Connection(object):
         wait_on_receipt = self.__wait_on_receipt and 'receipt' in merged_headers.keys()
         if wait_on_receipt:
             self.__send_wait_condition.acquire()
-        try: 
+        try:
             self.__send_frame_helper('SEND', message, merged_headers, [ 'destination' ])
             self.__notify('send', headers, message)
 
-            # if we need to wait-on-receipt, then block until the receipt frame arrives 
+            # if we need to wait-on-receipt, then block until the receipt frame arrives
             if wait_on_receipt:
                 receipt = merged_headers['receipt']
                 while receipt not in self.__receipts:
@@ -441,13 +457,13 @@ class Connection(object):
         finally:
             if wait_on_receipt:
                 self.__send_wait_condition.release()
-    
+
     def ack(self, headers={}, **keyword_headers):
         """
         Send an ACK frame, to acknowledge receipt of a message
         """
         self.__send_frame_helper('ACK', '', utils.merge_headers([headers, keyword_headers]), [ 'message-id' ])
-        
+
     def nack(self, headers={}, **keyword_headers):
         """
         Send an NACK frame, to acknowledge a message was not successfully processed
@@ -455,13 +471,13 @@ class Connection(object):
         if self.version < 1.1:
             raise RuntimeError('NACK is not supported with 1.0 connections')
         self.__send_frame_helper('NACK', '', utils.merge_headers([headers, keyword_headers]), [ 'message-id' ])
-        
+
     def begin(self, headers={}, **keyword_headers):
         """
         Send a BEGIN frame to start a transaction
         """
         use_headers = utils.merge_headers([headers, keyword_headers])
-        if not 'transaction' in use_headers.keys(): 
+        if not 'transaction' in use_headers.keys():
             use_headers['transaction'] = str(uuid.uuid4())
         self.__send_frame_helper('BEGIN', '', use_headers, [ 'transaction' ])
         return use_headers['transaction']
@@ -471,7 +487,7 @@ class Connection(object):
         Send an ABORT frame to rollback a transaction
         """
         self.__send_frame_helper('ABORT', '', utils.merge_headers([headers, keyword_headers]), [ 'transaction' ])
-        
+
     def commit(self, headers={}, **keyword_headers):
         """
         Send a COMMIT frame to commit a transaction (send pending messages)
@@ -486,7 +502,7 @@ class Connection(object):
         if 'wait' in keyword_headers and keyword_headers['wait']:
             wait = True
             del keyword_headers['wait']
-            
+
         if self.version >= 1.1:
             if self.__strict:
                 cmd = 'STOMP'
@@ -501,10 +517,10 @@ class Connection(object):
         self.__send_frame_helper(cmd, '', utils.merge_headers([self.__connect_headers, headers, keyword_headers]), [ ])
         if wait:
             self.__connect_wait_condition.acquire()
-            while not self.is_connected(): 
+            while not self.is_connected():
                 self.__connect_wait_condition.wait()
             self.__connect_wait_condition.release()
-        
+
     def disconnect_socket(self):
         self.__running = False
         if self.__socket is not None:
@@ -537,7 +553,7 @@ class Connection(object):
                 _, e, _ = sys.exc_info()
                 log.warn('Unable to close socket because of error "%s"' % e)
         self.__current_host_and_port = None
-        
+
     def disconnect(self, send_disconnect=True, headers={}, **keyword_headers):
         """
         Send a DISCONNECT frame to finish a connection
@@ -604,40 +620,40 @@ class Connection(object):
     def __send_frame(self, command, headers={}, payload=''):
         """
         Send a STOMP frame.
-        
+
         \param command
             the frame command
-        
+
         \param headers
             a map of headers (key-val pairs)
-        
+
         \param payload
             the message payload
         """
         if type(payload) == dict:
             headers["transformation"] = "jms-map-xml"
-            payload = self.__convert_dict(payload)  
+            payload = self.__convert_dict(payload)
 
         if payload:
             payload = encode(payload)
 
             if hasbyte(0, payload):
                 headers.update({'content-length': len(payload)})
-            
+
         if self.__socket is not None:
             try:
-                frame = [ ]                
+                frame = [ ]
                 if command is not None:
                     frame.append(command + '\n')
-                    
+
                 for key, val in headers.items():
                     frame.append('%s:%s\n' % (key, val))
-                        
+
                 frame.append('\n')
-                    
+
                 if payload:
                     frame.append(payload)
-                    
+
                 if command is not None:
                     # only send the terminator if we're sending a command (heartbeats have no term)
                     frame.append(NULL)
@@ -658,13 +674,13 @@ class Connection(object):
     def __notify(self, frame_type, headers=None, body=None):
         """
         Utility function for notifying listeners of incoming and outgoing messages
-        
+
         \param frame_type
             the type of message
-        
+
         \param headers
             the map of headers associated with the message
-        
+
         \param body
             the content of the message
         """
@@ -677,7 +693,7 @@ class Connection(object):
                 self.__send_wait_condition.notify()
             finally:
                 self.__send_wait_condition.release()
-            
+
 
             # received a stomp 1.1 disconnect receipt
             if receipt == self.__disconnect_receipt:
@@ -732,7 +748,7 @@ class Connection(object):
                         try:
                             while self.__running:
                                 frames = self.__read()
-                                
+
                                 for frame in frames:
                                     (frame_type, headers, body) = utils.parse_frame(frame)
                                     log.debug("Received frame: %r, headers=%r, body=%r" % (frame_type, headers, body))
@@ -770,16 +786,16 @@ class Connection(object):
             self.__receiver_thread_exit_condition.notifyAll()
             self.__receiver_thread_exit_condition.release()
             log.debug("Receiver loop ended")
-            
+
     def __heartbeat_loop(self):
         """
         Loop for sending (and monitoring received) heartbeats
         """
         send_sleep = self.heartbeats[0] / 1000
-        
+
         # receive gets an additional threshold of 3 additional seconds
         receive_sleep = (self.heartbeats[1] / 1000) + 3
-        
+
         if send_sleep == 0:
             sleep_time = receive_sleep
         elif receive_sleep == 0:
@@ -787,18 +803,18 @@ class Connection(object):
         else:
             # sleep is the GCD of the send and receive times
             sleep_time = gcd(send_sleep, receive_sleep) / 2.0
-            
+
         send_time = time.time()
         receive_time = time.time()
-            
+
         while self.__running:
             time.sleep(sleep_time)
-            
+
             if time.time() - send_time > send_sleep:
                 send_time = time.time()
                 log.debug('Sending a heartbeat message')
                 self.__send_frame(None)
-            
+
             if time.time() - receive_time > receive_sleep:
                 if time.time() - self.__received_heartbeat > receive_sleep:
                     log.debug('Heartbeat timeout')
@@ -944,17 +960,17 @@ class Connection(object):
                         else:
                             cert_validation = ssl.CERT_NONE
                         self.__socket = ssl.wrap_socket(self.__socket, keyfile = self.__ssl_key_file,
-                                certfile = self.__ssl_cert_file, cert_reqs = cert_validation, 
+                                certfile = self.__ssl_cert_file, cert_reqs = cert_validation,
                                 ca_certs = self.__ssl_ca_certs, ssl_version = self.__ssl_version)
                     self.__socket.settimeout(self.__timeout)
                     if self.blocking is not None:
                         self.__socket.setblocking(self.blocking)
                     self.__socket.connect(host_and_port)
-                    
+
                     #
                     # Validate server cert
                     #
-                    if self.__ssl and self.__ssl_cert_validator: 
+                    if self.__ssl and self.__ssl_cert_validator:
                         cert = self.__socket.getpeercert()
                         (ok, errmsg) = apply(self.__ssl_cert_validator, (cert, host_and_port[0]))
                         if not ok:
@@ -973,8 +989,8 @@ class Connection(object):
                     log.warning("Could not connect to host %s, port %s: %s" % (host_and_port[0], host_and_port[1], exc))
 
             if self.__socket is None:
-                sleep_duration = (min(self.__reconnect_sleep_max, 
-                                      ((self.__reconnect_sleep_initial / (1.0 + self.__reconnect_sleep_increase)) 
+                sleep_duration = (min(self.__reconnect_sleep_max,
+                                      ((self.__reconnect_sleep_initial / (1.0 + self.__reconnect_sleep_increase))
                                        * math.pow(1.0 + self.__reconnect_sleep_increase, sleep_exp)))
                                   * (1.0 + random.random() * self.__reconnect_sleep_jitter))
                 sleep_end = time.time() + sleep_duration


### PR DESCRIPTION
 - SSLV3 is disabled by default in some builds due
   to being insecure. This patch fixes an attribute
   error that can be raised in such builds. It also
   handles future potential deprecations.
 - Default is still left at 'PROTOCOL_SSLv3' but additional
   fallbacks for other common ssl protocols exist. A debug
   log message is emitted detailing which version was
   selected.
 - Bump version string to 3.1.7
 - Editor cleaned up a lot of trailing whitespace automatically
   which makes it look like the patch changes more code than
   it actually does.