### PR TITLE
Support mixed string and bytes as input

### DIFF
--- a/stomp/backward2.py
+++ b/stomp/backward2.py
@@ -32,7 +32,7 @@ def pack(pieces=[]):
     """
     Join a list of strings together (note: py3 version differs)
     """
-    return ''.join(pieces)
+    return ''.join(encode(p) for p in pieces)
 
 
 def join(chars=[]):

--- a/stomp/test/p2_backward_test.py
+++ b/stomp/test/p2_backward_test.py
@@ -3,6 +3,14 @@ import unittest
 from stomp import backward2
 
 class TestBackward2(unittest.TestCase):
+    def test_pack_mixed_string_and_bytes(self):
+        lines = ['SEND', '\n', u'header1:test', u'\u6771']
+        self.assertEqual(backward2.encode(backward2.pack(lines)),
+                         'SEND\nheader1:test\xe6\x9d\xb1')
+        lines = ['SEND', '\n', u'header1:test', '\xe6\x9d\xb1']
+        self.assertEqual(backward2.encode(backward2.pack(lines)),
+                         'SEND\nheader1:test\xe6\x9d\xb1')
+
     def test_decode(self):
         self.assertTrue(backward2.decode(None) is None)
         self.assertEquals(b'test', backward2.decode(b'test'))

--- a/stomp/test/p3_backward_test.py
+++ b/stomp/test/p3_backward_test.py
@@ -3,6 +3,14 @@ import unittest
 from stomp import backward3
 
 class TestBackward3(unittest.TestCase):
+    def test_pack_mixed_string_and_bytes(self):
+        lines = ['SEND', '\n', u'header1:test', u'\u6771']
+        self.assertEqual(backward3.encode(backward3.pack(lines)),
+                         b'SEND\nheader1:test\xe6\x9d\xb1')
+        lines = ['SEND', '\n', u'header1:test', b'\xe6\x9d\xb1']
+        self.assertEqual(backward3.encode(backward3.pack(lines)),
+                         b'SEND\nheader1:test\xe6\x9d\xb1')
+
     def test_decode(self):
         self.assertTrue(backward3.decode(None) is None)
         self.assertEquals('test', backward3.decode(b'test'))


### PR DESCRIPTION
Some smart programmers may cautiously encode a unicode string to "bytestring" when setting their message body/headers, however this would currently fail on python 2 if they left in any unicode; even an empty unicode literal (`u''`).

By encoding each frame part before packing (as we [already do for Python 3](https://github.com/jasonrbriggs/stomp.py/blob/master/stomp/backward3.py#L48)) we avoid raising a `UnicodeDecodeError` for perfectly encoded bunch of strings.

Without this "part-by-part encoding", both py2 and py3 version of pack would fail `test_pack_mixed_string_and_bytes`, so I added the test to both, and with the fix both now pass.