### PR TITLE
Toggle sending of `content-length` header

### DIFF
--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -67,14 +67,15 @@ class StompConnection10(BaseConnection, Protocol10):
                  ssl_version=DEFAULT_SSL_VERSION,
                  timeout=None,
                  keepalive=None,
-                 auto_decode=True):
+                 auto_decode=True,
+                 suppress_content_length=False):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,
                               ssl_ca_certs, ssl_cert_validator, wait_on_receipt, ssl_version, timeout,
                               keepalive, None, auto_decode)
         BaseConnection.__init__(self, transport)
-        Protocol10.__init__(self, transport)
+        Protocol10.__init__(self, transport, suppress_content_length)
 
     def disconnect(self, receipt=str(uuid.uuid4()), headers={}, **keyword_headers):
         """
@@ -113,14 +114,15 @@ class StompConnection11(BaseConnection, Protocol11):
                  heartbeats=(0, 0),
                  keepalive=None,
                  vhost=None,
-                 auto_decode=True):
+                 auto_decode=True,
+                 suppress_content_length=False):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,
                               ssl_ca_certs, ssl_cert_validator, wait_on_receipt, ssl_version, timeout,
                               keepalive, vhost, auto_decode)
         BaseConnection.__init__(self, transport)
-        Protocol11.__init__(self, transport, heartbeats)
+        Protocol11.__init__(self, transport, heartbeats, suppress_content_length)
 
     def disconnect(self, receipt=str(uuid.uuid4()), headers={}, **keyword_headers):
         """
@@ -159,14 +161,15 @@ class StompConnection12(BaseConnection, Protocol12):
                  heartbeats=(0, 0),
                  keepalive=None,
                  vhost=None,
-                 auto_decode=True):
+                 auto_decode=True,
+                 suppress_content_length=False):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,
                               ssl_ca_certs, ssl_cert_validator, wait_on_receipt, ssl_version, timeout,
                               keepalive, vhost, auto_decode)
         BaseConnection.__init__(self, transport)
-        Protocol12.__init__(self, transport, heartbeats)
+        Protocol12.__init__(self, transport, heartbeats, suppress_content_length)
 
     def disconnect(self, receipt=str(uuid.uuid4()), headers={}, **keyword_headers):
         """

--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -17,8 +17,9 @@ class Protocol10(ConnectionListener):
     
     Most users should not instantiate the protocol directly. See :py:mod:`stomp.connect` for connection classes.
     """
-    def __init__(self, transport):
+    def __init__(self, transport, suppress_content_length=False):
         self.transport = transport
+        self.suppress_content_length = suppress_content_length
         transport.set_listener('protocol-listener', self)
         self.version = '1.0'
 
@@ -149,7 +150,7 @@ class Protocol10(ConnectionListener):
         if content_type:
             headers[HDR_CONTENT_TYPE] = content_type
         body = encode(body)
-        if body and HDR_CONTENT_LENGTH not in headers:
+        if not self.suppress_content_length and body and HDR_CONTENT_LENGTH not in headers:
             headers[HDR_CONTENT_LENGTH] = len(body)
         self.send_frame(CMD_SEND, headers, body)
 
@@ -197,9 +198,10 @@ class Protocol11(HeartbeatListener, ConnectionListener):
     
     Most users should not instantiate the protocol directly. See :py:mod:`stomp.connect` for connection classes.
     """
-    def __init__(self, transport, heartbeats=(0, 0)):
+    def __init__(self, transport, heartbeats=(0, 0), suppress_content_length=False):
         HeartbeatListener.__init__(self, heartbeats)
         self.transport = transport
+        self.suppress_content_length = suppress_content_length
         transport.set_listener('protocol-listener', self)
         self.version = '1.1'
 
@@ -361,7 +363,7 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         if content_type:
             headers[HDR_CONTENT_TYPE] = content_type
         body = encode(body)
-        if body and HDR_CONTENT_LENGTH not in headers:
+        if not self.suppress_content_length and body and HDR_CONTENT_LENGTH not in headers:
             headers[HDR_CONTENT_LENGTH] = len(body)
         self.send_frame(CMD_SEND, headers, body)
 
@@ -402,8 +404,8 @@ class Protocol12(Protocol11):
     
     Most users should not instantiate the protocol directly. See :py:mod:`stomp.connect` for connection classes.
     """
-    def __init__(self, transport, heartbeats=(0, 0)):
-        Protocol11.__init__(self, transport, heartbeats)
+    def __init__(self, transport, heartbeats=(0, 0), suppress_content_length=False):
+        Protocol11.__init__(self, transport, heartbeats, suppress_content_length)
         self.version = '1.2'
 
     def _escape_headers(self, headers):


### PR DESCRIPTION
ActiveMQ interprets every message as a `BinaryMessage` if `content-length` header is included.

Using `surpress_content_length=True` will suppress this behavior and ActiveMQ will interpret the message as a `TextMessage`.

For more information refer to [ActiveMQ documentation](http://activemq.apache.org/stomp.html#Stomp-WorkingwithJMSText/BytesMessagesandStomp).


This feature mimics ruby and go stomp clients, who both have a similar feature:
* [stompgem/stomp](https://github.com/stompgem/stomp/blob/d8e0fc9446c45ef265586b0a24bf6ae518258dc0/lib/connection/netio.rb#L150)
* [go-stomp/stomp](https://github.com/go-stomp/stomp/blob/2cdbc0ba806049269c2738d0c9b5d2eb5cc2a129/send_options.go#L13)
