### PR TITLE
Set up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
+  - "pypy3"
+script:
+  - python setup.py test --test=ss_test
+  - python setup.py test --test=transport_test
+  - python setup.py test --test=utils_test

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Rafael Durán Casteñada
 Chaskiel Grundman  
 Ville Skyttä
 
+Build Status
+------------
+
+[![Build Status](https://travis-ci.org/jasonrbriggs/stomp.py.svg)](https://travis-ci.org/jasonrbriggs/stomp.py)


### PR DESCRIPTION
To get Travis going with stomp.py would be a matter of following steps 1 and 2 at http://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A , then merging this PR, and proceeding to step 5.

Currently Travis will be running tests that don't assume an "external" STOMP server running somewhere, but I suppose it wouldn't be impossible to get the rest of the tests to run too.

Note that mostly for cosmetic purposes at least for now, ```.travis.yml``` could include:
```yaml
install:
  - pip install coverage
```
...but that causes the 3.2, pypy, and pypy3 builds to fail at the moment for reasons that are not fixable in stomp.py so I didn't include it.