### PR TITLE
Heartbeat flexibility to support ActiveMQ

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -175,8 +175,8 @@ class HeartbeatListener(ConnectionListener):
             if self.heartbeats != (0, 0):
                 self.send_sleep = self.heartbeats[0] / 1000
 
-                # receive gets an additional threshold of 2 additional seconds
-                self.receive_sleep = (self.heartbeats[1] / 1000) + 2
+                # receive gets an additional grace of 50%
+                self.receive_sleep = (self.heartbeats[1] / 1000) * 1.5
 
                 if self.send_sleep == 0:
                     self.sleep_time = self.receive_sleep

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -201,9 +201,7 @@ class HeartbeatListener(ConnectionListener):
         :param body: the message content
         """
         # reset the heartbeat for any received message
-        # as long as we've had an actual heartbeat
-        if self.received_heartbeat is not None:
-            self.received_heartbeat = monotonic()
+        self.received_heartbeat = monotonic()
 
     def on_heartbeat(self):
         """

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -252,7 +252,6 @@ class HeartbeatListener(ConnectionListener):
                     log.warn("Heartbeat timeout: diff_receive=%s, time=%s, lastrec=%s", diff_receive, now, self.received_heartbeat)
                     self.transport.disconnect_socket()
                     self.transport.set_connected(False)
-                    self.running = False
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
 

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -253,6 +253,7 @@ class HeartbeatListener(ConnectionListener):
                     log.warn("Heartbeat timeout: diff_receive=%s, time=%s, lastrec=%s", diff_receive, now, self.received_heartbeat)
                     self.transport.disconnect_socket()
                     self.transport.set_connected(False)
+                    self.running = False
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
 


### PR DESCRIPTION
I was not able to make stomp.py work with ActiveMQ when the heartbeat was activate because stomp.py would fire a heartbeat timeout and disconnect. Some of the issue seemed to be that by default ActiveMQ backs off the first heartbeat by the same as the heartbeat timeout, effectively skipping the first beat. Also, the 2 second grace on the receive heartbeat didn't always seem sufficient. In ActiveMQ they suggest a 50% grace, which I've implemented here.

Also, I removed diff_heartbeat as it was identical logic to diff_receive.

Finally, I put some guard code around the heartbeat sending and receiving because if I just was to enable client heartbeats, and have the server heartbeat at 0 then the code as it stood would timeout immediately.