### PR TITLE
Label next version as 4.1.10 instead of 4.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Version 4.2.0
+Version 4.1.10
 
  * Bug fix for header escaping (https://github.com/jasonrbriggs/stomp.py/issues/82)
  * Merge patches from Ville S:


### PR DESCRIPTION
Looks like the next version will not have any real backwards incompatibilities, so I suggest labeling it as 4.1.10 instead of 4.2.0 in order to not cause unnecessary churn with dependencies specified e.g. like ```stomp.py~=4.1.9```