### PR TITLE
More accurate heartbeat timing

### DIFF
--- a/stomp/adapter/multicast.py
+++ b/stomp/adapter/multicast.py
@@ -117,7 +117,7 @@ class MulticastConnection(BaseConnection, Protocol12):
         elif cmd == CMD_COMMIT:
             trans = headers[HDR_TRANSACTION]
             if trans not in self.transactions:
-                self.notify('error', {}, 'Transaction % not started' % trans)
+                self.notify('error', {}, 'Transaction %s not started' % trans)
             else:
                 for f in self.transactions[trans]:
                     self.transport.transmit(f)

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -6,7 +6,7 @@ import sys
 import threading
 import time
 
-from stomp.backward import gcd, monotonic
+from stomp.backward import monotonic
 from stomp.constants import *
 import stomp.exception as exception
 import stomp.utils as utils
@@ -153,6 +153,7 @@ class HeartbeatListener(ConnectionListener):
         self.heartbeats = heartbeats
         self.received_heartbeat = None
         self.heartbeat_thread = None
+        self.next_outbound_heartbeat = None
 
     def on_connected(self, headers, body):
         """
@@ -171,23 +172,15 @@ class HeartbeatListener(ConnectionListener):
                 # receive gets an additional grace of 50%
                 self.receive_sleep = (self.heartbeats[1] / 1000) * 1.5
 
-                # Setup an initial grace period
-                if self.receive_sleep != 0:
-                    self.received_heartbeat = monotonic() + \
-                        2 * self.receive_sleep
-
-                if self.send_sleep == 0:
-                    self.sleep_time = self.receive_sleep
-                elif self.receive_sleep == 0:
-                    self.sleep_time = self.send_sleep
-                else:
-                    # sleep is the GCD of the send and receive times
-                    self.sleep_time = gcd(self.send_sleep, self.receive_sleep) / 2.0
+                # Give grace of receiving the first heartbeat
+                self.received_heartbeat = monotonic() + self.receive_sleep
 
                 self.running = True
                 if self.heartbeat_thread is None:
-                    self.heartbeat_thread = utils.default_create_thread(self.__heartbeat_loop)
-                    self.heartbeat_thread.name = "StompHeartbeat%s" % getattr(self.heartbeat_thread, "name", "Thread")
+                    self.heartbeat_thread = utils.default_create_thread(
+                        self.__heartbeat_loop)
+                    self.heartbeat_thread.name = "StompHeartbeat%s" % \
+                        getattr(self.heartbeat_thread, "name", "Thread")
 
     def on_disconnected(self):
         self.running = False
@@ -200,25 +193,25 @@ class HeartbeatListener(ConnectionListener):
         :param body: the message content
         """
         # reset the heartbeat for any received message
-        self.received_heartbeat = monotonic()
+        self.__update_heartbeat()
 
     def on_receipt(self, *_):
         """
         Reset the last received time whenever a receipt is received.
         """
-        self.received_heartbeat = monotonic()
+        self.__update_heartbeat()
 
     def on_error(self, *_):
         """
         Reset the last received time whenever an error is received.
         """
-        self.received_heartbeat = monotonic()
+        self.__update_heartbeat()
 
     def on_heartbeat(self):
         """
         Reset the last received time whenever a heartbeat message is received.
         """
-        self.received_heartbeat = monotonic()
+        self.__update_heartbeat()
 
     def on_send(self, frame):
         """
@@ -230,19 +223,40 @@ class HeartbeatListener(ConnectionListener):
             if self.heartbeats != (0, 0):
                 frame.headers[HDR_HEARTBEAT] = '%s,%s' % self.heartbeats
 
+    def __update_heartbeat(self):
+        # Honour any grace that has been already included
+        now = monotonic()
+        if now > self.received_heartbeat:
+            self.received_heartbeat = now
+
     def __heartbeat_loop(self):
         """
         Main loop for sending (and monitoring received) heartbeats.
         """
-        send_time = monotonic()
+        now = monotonic()
+
+        # Setup the initial due time for the outbound heartbeat
+        if self.send_sleep != 0:
+            self.next_outbound_heartbeat = now + self.send_sleep
 
         while self.running:
-            time.sleep(self.sleep_time)
+            now = monotonic()
+
+            next_events = []
+            if self.next_outbound_heartbeat is not None:
+                next_events.append(self.next_outbound_heartbeat-now)
+            if self.receive_sleep != 0:
+                next_events.append(self.received_heartbeat + self.receive_sleep
+                                   - now)
+            sleep_time = min(next_events)
+            if sleep_time > 0:
+                time.sleep(sleep_time)
 
             now = monotonic()
 
-            if self.send_sleep != 0 and now - send_time > self.send_sleep:
-                send_time = now
+            if self.send_sleep != 0 and now > self.next_outbound_heartbeat:
+                self.next_outbound_heartbeat = now + self.send_sleep
+
                 log.debug("Sending a heartbeat message at %s", now)
                 try:
                     self.transport.transmit(utils.Frame(None, {}, None))

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -271,7 +271,7 @@ class HeartbeatListener(ConnectionListener):
 
                 if diff_receive > self.receive_sleep:
                     # heartbeat timeout
-                    log.warn("Heartbeat timeout: diff_receive=%s, time=%s, lastrec=%s", diff_receive, now, self.received_heartbeat)
+                    log.warning("Heartbeat timeout: diff_receive=%s, time=%s, lastrec=%s", diff_receive, now, self.received_heartbeat)
                     self.transport.disconnect_socket()
                     self.transport.set_connected(False)
                     for listener in self.transport.listeners.values():

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -225,6 +225,8 @@ class HeartbeatListener(ConnectionListener):
 
     def __update_heartbeat(self):
         # Honour any grace that has been already included
+        if self.received_heartbeat is None:
+            return
         now = monotonic()
         if now > self.received_heartbeat:
             self.received_heartbeat = now

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -276,6 +276,7 @@ class HeartbeatListener(ConnectionListener):
                     self.transport.set_connected(False)
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
+        self.heartbeat_thread = None
 
 
 class WaitingListener(ConnectionListener):

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -198,7 +198,6 @@ class BaseTransport(stomp.listener.Publisher):
         elif frame_type == 'disconnected':
             self.set_connected(False)
 
-        rtn = None
         for listener in self.listeners.values():
             if not listener:
                 continue
@@ -222,10 +221,7 @@ class BaseTransport(stomp.listener.Publisher):
             rtn = notify_func(headers, body)
             if rtn:
                 (headers, body) = rtn
-        if rtn:
-            return rtn
-        else:
-            return (headers, body)
+        return (headers, body)
 
     def transmit(self, frame):
         """

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -165,11 +165,11 @@ class BaseTransport(stomp.listener.Publisher):
         if frame_type in ['connected', 'message', 'receipt', 'error', 'heartbeat']:
             if frame_type == 'message':
                 (f.headers, f.body) = self.notify('before_message', f.headers, f.body)
-            self.notify(frame_type, f.headers, f.body)
             if log.isEnabledFor(logging.DEBUG):
                 log.debug("Received frame: %r, headers=%r, body=%r", f.cmd, f.headers, f.body)
             else:
                 log.info("Received frame: %r, headers=%r, len(body)=%r", f.cmd, f.headers, utils.length(f.body))
+            self.notify(frame_type, f.headers, f.body)
         else:
             log.warning("Unknown response frame type: '%s' (frame length was %d)", frame_type, utils.length(frame_str))
 

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -539,7 +539,7 @@ class Transport(BaseTransport):
                     # unwrap seems flaky on Win with the back-ported ssl mod, so catch any exception and log it
                     #
                     _, e, _ = sys.exc_info()
-                    log.warn(e)
+                    log.warning(e)
             elif hasattr(socket, 'SHUT_RDWR'):
                 try:
                     self.socket.shutdown(socket.SHUT_RDWR)
@@ -547,7 +547,7 @@ class Transport(BaseTransport):
                     _, e, _ = sys.exc_info()
                     # ignore when socket already closed
                     if get_errno(e) != errno.ENOTCONN:
-                        log.warn("Unable to issue SHUT_RDWR on socket because of error '%s'", e)
+                        log.warning("Unable to issue SHUT_RDWR on socket because of error '%s'", e)
 
         #
         # split this into a separate check, because sometimes the socket is nulled between shutdown and this call
@@ -557,7 +557,7 @@ class Transport(BaseTransport):
                 self.socket.close()
             except socket.error:
                 _, e, _ = sys.exc_info()
-                log.warn("Unable to close socket because of error '%s'", e)
+                log.warning("Unable to close socket because of error '%s'", e)
         self.current_host_and_port = None
 
     def send(self, encoded_frame):

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -224,6 +224,8 @@ class BaseTransport(stomp.listener.Publisher):
                 (headers, body) = rtn
         if rtn:
             return rtn
+        else:
+            return (headers, body)
 
     def transmit(self, frame):
         """


### PR DESCRIPTION
The original heartbeat thread was prone to missing heartbeat sends due to the accuracy of the sleep timing. This modification calculates the sleep time based on when the next event is required, instead of being a fixed time. An example of the old code missing sleeps is here:

2016-03-07 14:34:30 stomp.py     INFO     Sending frame cmd='STOMP' headers={'passcode': 'xxx', 'login': 'xxx', 'accept-version': '1.1', 'heart-beat': '10000,0'}
2016-03-07 14:34:40 stomp.py     INFO     Sending frame cmd=None headers={}
2016-03-07 14:34:50 stomp.py     INFO     Sending frame cmd=None headers={}
2016-03-07 14:35:00 stomp.py     INFO     Sending frame cmd=None headers={}
2016-03-07 14:35:10 stomp.py     INFO     Sending frame cmd=None headers={}
2016-03-07 14:35:30 stomp.py     INFO     Sending frame cmd=None headers={}
2016-03-07 14:35:50 stomp.py     INFO     Sending frame cmd=None headers={}

Additionally there is a cleanup of the heartbeat thread reference so that the thread is properly restarted if we reconnect following a timeout.