### PR TITLE
setup.py: Import stomp after logging config to get some output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,13 @@ import shutil
 import sys
 import unittest
 
-import stomp
-
 try:
     logging.config.fileConfig('stomp.log.conf')
 except:
     pass
+
+# Import this after configuring logging
+import stomp
 
 
 class TestCommand(Command):


### PR DESCRIPTION
Makes it easier to follow what goes on with the tests. But also exposes an issue of some kind with testheartbeat_timeout (stomp.test.s11_test.Test11Send) -- a heartbeat timeout storm follows. I didn't find an obvious reason for that on a quick peek.