### PR TITLE
Deprecate no-op wait_on_receipt arg to transport and connection

### DIFF
--- a/stomp/__main__.py
+++ b/stomp/__main__.py
@@ -53,11 +53,11 @@ class StompCLI(Cmd, ConnectionListener):
         self.passcode = passcode
         self.__quit = False
         if ver == '1.0':
-            self.conn = StompConnection10([(host, port)], wait_on_receipt=True)
+            self.conn = StompConnection10([(host, port)])
         elif ver == '1.1':
-            self.conn = StompConnection11([(host, port)], wait_on_receipt=True, heartbeats=heartbeats)
+            self.conn = StompConnection11([(host, port)], heartbeats=heartbeats)
         elif ver == '1.2':
-            self.conn = StompConnection12([(host, port)], wait_on_receipt=True, heartbeats=heartbeats)
+            self.conn = StompConnection12([(host, port)], heartbeats=heartbeats)
         elif ver == 'multicast':
             self.conn = MulticastConnection()
         else:

--- a/stomp/adapter/multicast.py
+++ b/stomp/adapter/multicast.py
@@ -95,7 +95,7 @@ class MulticastTransport(Transport):
 class MulticastConnection(BaseConnection, Protocol12):
     def __init__(self, wait_on_receipt=False):
         """
-        :param bool wait_on_receipt:
+        :param bool wait_on_receipt: deprecated, ignored
         """
         self.transport = MulticastTransport()
         self.transport.set_listener('mcast-listener', self)

--- a/stomp/test/transport_test.py
+++ b/stomp/test/transport_test.py
@@ -6,7 +6,7 @@ import stomp
 
 class TestTransport(unittest.TestCase):
     def setUp(self):
-        self.transport = stomp.transport.BaseTransport(None)
+        self.transport = stomp.transport.BaseTransport()
 
     def test_process_frame_unknown_command_empty_body(self):
         fr = stomp.utils.Frame('test', {}, None)

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -50,9 +50,7 @@ class BaseTransport(stomp.listener.Publisher):
     and anything else outside of actually establishing a network connection, sending and
     receiving of messages (so generally socket-agnostic functions).
 
-    :param bool wait_on_receipt: if a receipt is specified, then the send method should wait
-        (block) for the server to respond with that receipt-id
-        before continuing
+    :param bool wait_on_receipt: deprecated, ignored
     :param bool auto_decode: automatically decode message responses as strings, rather than
         leaving them as bytes. This preserves the behaviour as of version 4.0.16.
         (To be defaulted to False as of the next release)
@@ -63,7 +61,7 @@ class BaseTransport(stomp.listener.Publisher):
     #
     __content_length_re = re.compile(b'^content-length[:]\\s*(?P<value>[0-9]+)', re.MULTILINE)
 
-    def __init__(self, wait_on_receipt, auto_decode=True):
+    def __init__(self, wait_on_receipt=False, auto_decode=True):
         self.__recvbuf = b''
         self.listeners = {}
         self.running = False
@@ -71,7 +69,6 @@ class BaseTransport(stomp.listener.Publisher):
         self.connected = False
         self.connection_error = False
         self.__receipts = {}
-        self.__wait_on_receipt = wait_on_receipt
         self.current_host_and_port = None
 
         # flag used when we receive the disconnect receipt
@@ -437,7 +434,7 @@ class Transport(BaseTransport):
     :param ssl_cert_validator: deprecated, see :py:meth:`set_ssl`
     :param ssl_version: deprecated, see :py:meth:`set_ssl`
     :param timeout: the timeout value to use when connecting the stomp socket
-    :param bool wait_on_receipt:
+    :param bool wait_on_receipt: deprecated, ignored
     :param keepalive: some operating systems support sending the occasional heart
         beat packets to detect when a connection fails.  This
         parameter can either be set set to a boolean to turn on the


### PR DESCRIPTION
The wait_on_receipt arg to transport and connection doesn't actually do anything besides setting `transport.__wait_on_receipt` which isn't used by anything in the tree, so I suggest deprecating it.