### PR TITLE
Use valid test frames

### DIFF
--- a/stomp/test/s11_test.py
+++ b/stomp/test/s11_test.py
@@ -60,10 +60,12 @@ class Test11Send(unittest.TestCase):
         server.start()
         try:
             server.add_frame('''CONNECTED
-version: 1.1
-session: 1
-server: test
-heart-beat: 1000,1000\x00''')
+version:1.1
+session:1
+server:test
+heart-beat:1000,1000
+
+\x00''')
 
             conn = stomp.Connection([('127.0.0.1', 60000)], heartbeats=(1000, 1000))
             listener = TestListener()

--- a/stomp/test/ss_test.py
+++ b/stomp/test/ss_test.py
@@ -25,10 +25,12 @@ class TestWithStompServer(unittest.TestCase):
 
     def test_disconnect(self):
         self.server.add_frame('''CONNECTED
-version: 1.1
-session: 1
-server: test
-heart-beat: 1000,1000\x00''')
+version:1.1
+session:1
+server:test
+heart-beat:1000,1000
+
+\x00''')
 
         conn = stomp.Connection([('127.0.0.1', 60000)])
         listener = TestListener()
@@ -66,10 +68,12 @@ heart-beat: 1000,1000\x00''')
             time.sleep(2)
 
             self.server.add_frame('''CONNECTED
-version: 1.1
-session: 1
-server: test
-heart-beat: 1000,1000\x00''')
+version:1.1
+session:1
+server:test
+heart-beat:1000,1000
+
+\x00''')
 
             self.server.start()
 
@@ -91,10 +95,12 @@ heart-beat: 1000,1000\x00''')
         # Trailing optional EOLs in a frame
 
         self.server.add_frame('''CONNECTED
-version: 1.1
-session: 1
-server: test
-heart-beat: 1000,1000\x00''' + '\n\n\n')
+version:1.1
+session:1
+server:test
+heart-beat:1000,1000
+
+\x00''' + '\n\n\n')
         expected_heartbeat_count = 0
 
         conn = stomp.Connection([('127.0.0.1', 60000)])


### PR DESCRIPTION
Remove extra whitespace and add missing linefeeds to some test frames to make them valid.