### PR TITLE
Add a common exception class

### DIFF
--- a/stomp/exception.py
+++ b/stomp/exception.py
@@ -1,30 +1,35 @@
 """Errors thrown by stomp.py connections.
 """
 
+class StompException(Exception):
+    """
+    Common exception class. All specific stomp.py exceptions are subclasses
+    of StompException, allowing the library user to catch all current and
+    future library exceptions.
+    """
 
-class ConnectionClosedException(Exception):
+
+class ConnectionClosedException(StompException):
     """
     Raised in the receiver thread when the connection has been closed
     by the server.
     """
-    pass
 
 
-class NotConnectedException(Exception):
+class NotConnectedException(StompException):
     """
     Raised when there is currently no server connection.
     """
-    pass
 
 
-class ConnectFailedException(Exception):
+class ConnectFailedException(StompException):
     """
     Raised by Connection.attempt_connection when reconnection attempts
     have exceeded Connection.__reconnect_attempts_max.
     """
 
 
-class InterruptedException(Exception):
+class InterruptedException(StompException):
     """
     Raised by receive when data read is interrupted.
     """


### PR DESCRIPTION
Having multiple exceptions derived from Exception makes it more complex to catch all library errors. The usual strategy for this is to have one exception class per package and specific exceptions as subclasses of that one class. This also means I will be able to write code that can catch future stomp.py exceptions that have not yet been thought of.