### PR TITLE
Fix setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,12 @@ class TestCommand(Command):
             cov = None
 
         suite = unittest.TestSuite()
+        import stomp.test
         if self.test == '*':
             print('Running all tests')
             tests = stomp.test.__all__
         else:
             tests = self.test.split(',')
-        import stomp.test
         for tst in tests:
             suite.addTests(unittest.TestLoader().loadTestsFromName('stomp.test.%s' % tst))
 


### PR DESCRIPTION
Previously it threw this error:

```
> python3 setup.py test
running test
Running all tests
Traceback (most recent call last):
  File "setup.py", line 120, in <module>
    'Programming Language :: Python :: 3'
  File "/usr/lib64/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 41, in run
    tests = stomp.test.__all__
UnboundLocalError: local variable 'stomp' referenced before assignment
```