### PR TITLE
updating listeners should be thread safe

### DIFF
--- a/stomp/__init__.py
+++ b/stomp/__init__.py
@@ -12,7 +12,7 @@ Project Page: https://github.com/jasonrbriggs/stomp.py
 import stomp.connect as connect
 import stomp.listener as listener
 
-__version__ = (4, 1, 20)
+__version__ = (4, 1, 21)
 
 ##
 # Alias for STOMP 1.0 connections.


### PR DESCRIPTION
This allows clients to stop listening before shutdown without hitting things like:

Exception in thread StompReceiverThread-3:
Traceback (most recent call last):
  File "/projects/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/projects/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/projects/lib/python3.6/site-packages/stomp/transport.py", line 335, in __receiver_loop
    self.process_frame(f, frame)
  File "/projects/lib/python3.6/site-packages/stomp/transport.py", line 188, in process_frame
    self.notify(frame_type, f.headers, f.body)
  File "/projects/lib/python3.6/site-packages/stomp/transport.py", line 221, in notify
    for listener in self.listeners.values():
RuntimeError: dictionary changed size during iteration