### PR TITLE
Added configurable amount of recv bytes.

### DIFF
--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -94,7 +94,8 @@ class StompConnection10(BaseConnection, Protocol10):
                  timeout=None,
                  keepalive=None,
                  auto_decode=True,
-                 auto_content_length=True):
+                 auto_content_length=True,
+                 recv_bytes=1024):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,
@@ -146,7 +147,8 @@ class StompConnection11(BaseConnection, Protocol11):
                  vhost=None,
                  auto_decode=True,
                  auto_content_length=True,
-                 heart_beat_receive_scale=1.5):
+                 heart_beat_receive_scale=1.5,
+                 recv_byte=1024):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,
@@ -198,7 +200,8 @@ class StompConnection12(BaseConnection, Protocol12):
                  vhost=None,
                  auto_decode=True,
                  auto_content_length=True,
-                 heart_beat_receive_scale=1.5):
+                 heart_beat_receive_scale=1.5,
+                 recv_bytes=1024):
         transport = Transport(host_and_ports, prefer_localhost, try_loopback_connect,
                               reconnect_sleep_initial, reconnect_sleep_increase, reconnect_sleep_jitter,
                               reconnect_sleep_max, reconnect_attempts_max, use_ssl, ssl_key_file, ssl_cert_file,

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -481,6 +481,7 @@ class Transport(BaseTransport):
         values, which also enables keepalive packets, but specifies
         options specific to your OS implementation
     :param str vhost: specify a virtual hostname to provide in the 'host' header of the connection
+    :param int recv_bytes: the number of bytes to use when calling recv
     """
 
     def __init__(self,
@@ -502,7 +503,8 @@ class Transport(BaseTransport):
                  timeout=None,
                  keepalive=None,
                  vhost=None,
-                 auto_decode=True
+                 auto_decode=True,
+                 recv_bytes=1024
                  ):
         BaseTransport.__init__(self, wait_on_receipt, auto_decode)
 
@@ -563,6 +565,7 @@ class Transport(BaseTransport):
 
         self.__keepalive = keepalive
         self.vhost = vhost
+        self.__recv_bytes = recv_bytes
 
     def is_connected(self):
         """
@@ -636,7 +639,7 @@ class Transport(BaseTransport):
         :rtype: bytes
         """
         try:
-            return self.socket.recv(1024)
+            return self.socket.recv(self.__recv_bytes)
         except socket.error:
             _, e, _ = sys.exc_info()
             if get_errno(e) in (errno.EAGAIN, errno.EINTR):


### PR DESCRIPTION
When receiving large messages (in our case 30+MB) reading only one kilobyte at
a time can cause very long receive times. Adding a configurable receive time
lets a user set a large number of bytes to read per receive call and enables
receipt of large messages.