### PR TITLE
add missing receiver loop notification handler to base ConnectionListener

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Version 4.1.20 -
  * Make updating listeners thread-safe (https://github.com/jasonrbriggs/stomp.py/pull/174)
  * Merge patch from Scott W for configuring grace period for heartbeat timeouts (https://github.com/jasonrbriggs/stomp.py/pull/180)
  * Fix ack/nack in CLI
+ * Add missing on_receiver_loop_completed handler to ConnectionListener
 
 
 Version 4.1.19 -

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -145,6 +145,12 @@ class ConnectionListener(object):
         """
         pass
 
+    def on_receiver_loop_completed(self):
+        """
+        Called when the connection receiver_loop has finished.
+        """
+        pass
+
 
 class HeartbeatListener(ConnectionListener):
     """

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -145,7 +145,7 @@ class ConnectionListener(object):
         """
         pass
 
-    def on_receiver_loop_completed(self):
+    def on_receiver_loop_completed(self, headers, body):
         """
         Called when the connection receiver_loop has finished.
         """


### PR DESCRIPTION
Fix for https://github.com/jasonrbriggs/stomp.py/issues/187