### PR TITLE
Allow custom headers in nack calls

### DIFF
--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -362,7 +362,7 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         self.set_receipt(rec, CMD_DISCONNECT)
         self.send_frame(CMD_DISCONNECT, headers)
 
-    def nack(self, id, subscription, transaction=None, receipt=None):
+    def nack(self, id, subscription, transaction=None, receipt=None, headers=None, **keyword_headers):
         """
         Let the server know that a message was not consumed.
 
@@ -372,7 +372,7 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         """
         assert id is not None, "'id' is required"
         assert subscription is not None, "'subscription' is required"
-        headers = {HDR_MESSAGE_ID: id, HDR_SUBSCRIPTION: subscription}
+        headers = utils.merge_headers([headers, keyword_headers, {HDR_MESSAGE_ID: id, HDR_SUBSCRIPTION: subscription}])
         if transaction:
             headers[HDR_TRANSACTION] = transaction
         if receipt:
@@ -473,7 +473,7 @@ class Protocol12(Protocol11):
             headers[HDR_RECEIPT] = receipt
         self.send_frame(CMD_ACK, headers)
 
-    def nack(self, id, transaction=None, receipt=None):
+    def nack(self, id, transaction=None, receipt=None, headers=None, **keyword_headers):
         """
         Let the server know that a message was not consumed.
 
@@ -481,7 +481,7 @@ class Protocol12(Protocol11):
         :param str transaction: include this nack in a named transaction
         """
         assert id is not None, "'id' is required"
-        headers = {HDR_ID: id}
+        headers = utils.merge_headers([headers, keyword_headers, {HDR_ID: id}])
         if transaction:
             headers[HDR_TRANSACTION] = transaction
         if receipt:

--- a/stomp/test/rabbitmq_test.py
+++ b/stomp/test/rabbitmq_test.py
@@ -25,3 +25,35 @@ class TestRabbitMQSend(unittest.TestCase):
         self.assertTrue(listener.connections == 1, 'should have received 1 connection acknowledgement')
         self.assertTrue(listener.messages == 1, 'should have received 1 message')
         self.assertTrue(listener.errors == 0, 'should not have received any errors')
+
+    def test_clientnack_requeue(self):
+        conn = stomp.Connection11(get_rabbitmq_host())
+        listener = TestListener('123')
+        conn.set_listener('', listener)
+        conn.connect(get_rabbitmq_user(), get_rabbitmq_password(), wait=True)
+        queuename = '/queue/testnack'
+        conn.subscribe(destination=queuename, id=1, ack='client')
+        conn.send(body='this is a test', destination=queuename, receipt='123')
+
+        # Get the sent message
+        listener.wait_for_message()
+        (headers, _) = listener.get_latest_message()
+        message_id = headers['message-id']
+        subscription = headers['subscription']
+        self.assertTrue(listener.messages == 1, 'should have received 1 message')
+
+        # Nack with requeue=True, now the message should be again waiting in the queue
+        conn.nack(message_id, subscription, requeue=True)
+
+        # Get the requeued message
+        listener.wait_for_message()
+        (headers, _) = listener.get_latest_message()
+        message_id = headers['message-id']
+        subscription = headers['subscription']
+        self.assertTrue(listener.messages == 2, 'should have received 2 messages')
+
+        # Clean up
+        conn.nack(message_id, subscription, requeue=False)
+        listener.wait_on_receipt()
+        conn.disconnect(receipt=None)
+        self.assertTrue(listener.errors == 0, 'should not have received any errors')


### PR DESCRIPTION
RabbitMQ allows for custom headers in reject messages (requeue -header). This should be supported so that it is possible to tell Rabbit what it should do with those.

This of course changes the function signatures a bit :/