### PR TITLE
fixes #243 Credentials exposed

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -499,7 +499,7 @@ class PrintingListener(ConnectionListener):
         """
         :param Frame frame:
         """
-        print('on_send %s %s %s' % (frame.cmd, frame.headers, frame.body))
+        print('on_send %s %s %s' % (frame.cmd, utils.clean_headers(frame.headers), frame.body))
 
     def on_heartbeat(self):
         print('on_heartbeat')

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -274,7 +274,7 @@ class BaseTransport(stomp.listener.Publisher):
         packed_frame = pack(lines)
 
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("Sending frame: %s", lines)
+            log.debug("Sending frame: %s", utils.clean_lines(lines))
         else:
             log.info("Sending frame: %r", frame.cmd or "heartbeat")
         self.send(packed_frame)

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -50,6 +50,11 @@ PREAMBLE_END_RE = re.compile(b'\n\n|\r\n\r\n')
 #
 LINE_END_RE = re.compile('\n|\r\n')
 
+##
+# Used to replace the "passcode" to be dumped in the transport log (at debug level)
+#
+PASSCODE_RE = re.compile(r'\'passcode:[^\']*\'')
+
 ENC_NEWLINE = encode("\n")
 ENC_NULL = encode(NULL)
 
@@ -185,6 +190,11 @@ def clean_headers(headers):
         rtn = copy.copy(headers)
         rtn['passcode'] = '********'
     return rtn
+
+
+# lines: lines returned from a call to convert_frames
+def clean_lines(lines):
+    return re.sub(PASSCODE_RE, '\'passcode:********\\\\n\'', str(lines))
 
 
 def calculate_heartbeats(shb, chb):


### PR DESCRIPTION
fixed #243 by adding utils.clean_lines to mask passcode in the transport log (at debug level) and by using the existing utils.clean_headers to do the same in PrintingListener