### PR TITLE
remove name thread line to allow create multi-threads

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -109,7 +109,7 @@ class BaseTransport(stomp.listener.Publisher):
         self.running = True
         self.attempt_connection()
         receiver_thread = self.create_thread_fc(self.__receiver_loop)
-        receiver_thread.name = "StompReceiver%s" % getattr(receiver_thread, "name", "Thread")
+        # receiver_thread.name = "StompReceiver%s" % getattr(receiver_thread, "name", "Thread")
         self.notify('connecting')
 
     def stop(self):


### PR DESCRIPTION
I remove the line which name the thread we just created, so that we can create multiple threads by override_threading. In this case, self.create_thread_fc can return a thread list instead of a thread.

