### PR TITLE
Consider ``STOMP_SKIP_HOSTNAME_SCAN`` environment variable before extending ``LOCALHOST_NAMES``.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Version 4.1.23 -
 
  * Fix for credentials exposure (https://github.com/jasonrbriggs/stomp.py/pull/244)
- *  
+ * Check for ``STOMP_SKIP_HOSTNAME_SCAN`` environment variable before extending ``LOCALHOST_NAMES``
 
 
 Version 4.1.22 - Apr 2019

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -2,6 +2,7 @@
 """
 
 import copy
+import os
 import re
 import socket
 import threading
@@ -20,20 +21,21 @@ except ImportError:
 # preferred targets.
 LOCALHOST_NAMES = ["localhost", "127.0.0.1"]
 
-try:
-    LOCALHOST_NAMES.append(socket.gethostbyname(socket.gethostname()))
-except:
-    pass
+if not os.environ.get('STOMP_SKIP_HOSTNAME_SCAN'):
+    try:
+        LOCALHOST_NAMES.append(socket.gethostbyname(socket.gethostname()))
+    except Exception:
+        pass
 
-try:
-    LOCALHOST_NAMES.append(socket.gethostname())
-except:
-    pass
+    try:
+        LOCALHOST_NAMES.append(socket.gethostname())
+    except Exception:
+        pass
 
-try:
-    LOCALHOST_NAMES.append(socket.getfqdn(socket.gethostname()))
-except:
-    pass
+    try:
+        LOCALHOST_NAMES.append(socket.getfqdn(socket.gethostname()))
+    except Exception:
+        pass
 
 ##
 # Used to parse STOMP header lines in the format "key:value",
@@ -57,6 +59,7 @@ PASSCODE_RE = re.compile(r'\'passcode:[^\']*\'')
 
 ENC_NEWLINE = encode("\n")
 ENC_NULL = encode(NULL)
+
 
 def default_create_thread(callback):
     """


### PR DESCRIPTION
This is useful on systems where hostname lookup from socket times out, but application startup time is important. In my case this happened with a kivy application on iOS.