### PR TITLE
Fix missing return in get_ssl

### DIFF
--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -79,7 +79,7 @@ class BaseConnection(Publisher):
         self.transport.set_ssl(*args, **kwargs)
 
     def get_ssl(self, *args, **kwargs):
-        self.transport.get_ssl(*args, **kwargs)
+        return self.transport.get_ssl(*args, **kwargs)
 
 
 class StompConnection10(BaseConnection, Protocol10):


### PR DESCRIPTION
Otherwise there's no way to verify your SSL settings.