### PR TITLE
Fix documentation error in transport re: SSL/TLS

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -104,7 +104,8 @@ class BaseTransport(stomp.listener.Publisher):
         """
         Start the connection. This should be called after all
         listeners have been registered. If this method is not called,
-        no frames will be received by the connection.
+        no frames will be received by the connection and no SSL/TLS
+        handshake will occur.
         """
         self.running = True
         self.attempt_connection()
@@ -726,7 +727,7 @@ class Transport(BaseTransport):
         connect_count = 0
 
         while self.running and self.socket is None and (
-            connect_count < self.__reconnect_attempts_max or 
+            connect_count < self.__reconnect_attempts_max or
             self.__reconnect_attempts_max == -1 ):
             for host_and_port in self.__host_and_ports:
                 try:


### PR DESCRIPTION
All the SSL/TLS handshaking is in `attempt_connection()`, so even if you are only broadcasting (like I was), you still need to call `start()` if you want SSL/TLS.