### PR TITLE
clear HB event after heartbeatloop ended

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -303,6 +303,7 @@ class HeartbeatListener(ConnectionListener):
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
         self.heartbeat_thread = None
+        self.heartbeat_terminate_event.clear()
         log.info('Heartbeat loop ended')
 
 


### PR DESCRIPTION
if stompserver goes down and comes up the hearbeatloop would end immediately in 
```python
                terminate = self.heartbeat_terminate_event.wait(sleep_time)
                if terminate:
                    break
```
because the event was never cleared