### PR TITLE
Additional headers for NACK command

### DIFF
--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -358,17 +358,19 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         self.set_receipt(rec, CMD_DISCONNECT)
         self.send_frame(CMD_DISCONNECT, headers)
 
-    def nack(self, id, subscription, transaction=None, receipt=None):
+    def nack(self, id, subscription, transaction=None, receipt=None, **keyword_headers):
         """
         Let the server know that a message was not consumed.
 
         :param str id: the unique id of the message to nack
         :param str subscription: the subscription this message is associated with
         :param str transaction: include this nack in a named transaction
+        :param keyword_headers: any additional headers to send with the nack command
         """
         assert id is not None, "'id' is required"
         assert subscription is not None, "'subscription' is required"
         headers = {HDR_MESSAGE_ID: id, HDR_SUBSCRIPTION: subscription}
+        headers = utils.merge_headers([headers, keyword_headers])
         if transaction:
             headers[HDR_TRANSACTION] = transaction
         if receipt:
@@ -468,15 +470,17 @@ class Protocol12(Protocol11):
             headers[HDR_RECEIPT] = receipt
         self.send_frame(CMD_ACK, headers)
 
-    def nack(self, id, transaction=None, receipt=None):
+    def nack(self, id, transaction=None, receipt=None, **keyword_headers):
         """
         Let the server know that a message was not consumed.
 
         :param str id: the unique id of the message to nack
         :param str transaction: include this nack in a named transaction
+        :param keyword_headers: any additional headers to send with the nack command
         """
         assert id is not None, "'id' is required"
         headers = {HDR_ID: id}
+        headers = utils.merge_headers([headers, keyword_headers])
         if transaction:
             headers[HDR_TRANSACTION] = transaction
         if receipt:

--- a/stomp/test/basic_test.py
+++ b/stomp/test/basic_test.py
@@ -1,4 +1,3 @@
-import os
 import signal
 import time
 import unittest
@@ -6,7 +5,6 @@ from unittest import mock
 
 import stomp
 from stomp import exception
-from stomp.backward import monotonic
 from stomp.constants import HDR_MESSAGE_ID, HDR_SUBSCRIPTION, CMD_NACK
 from stomp.listener import TestListener
 from stomp.test.testutils import *

--- a/stomp/test/s12_test.py
+++ b/stomp/test/s12_test.py
@@ -1,5 +1,9 @@
 import time
 import unittest
+from unittest import mock
+
+from stomp.constants import CMD_NACK, HDR_ID
+
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -65,6 +69,23 @@ class Test12Connect(unittest.TestCase):
         ack_id = headers['ack']
 
         self.conn.nack(ack_id)
+
+    def test_should_send_extra_header_clientnack(self):
+        queuename = '/queue/testclientnack12-%s' % self.timestamp
+        self.conn.subscribe(destination=queuename, id=1, ack='client-individual')
+
+        self.conn.send(body='this is a test', destination=queuename, receipt='123')
+
+        self.listener.wait_for_message()
+
+        (headers, _) = self.listener.get_latest_message()
+
+        ack_id = headers['ack']
+
+        with mock.patch.object(self.conn, "send_frame", wraps=self.conn.send_frame) as wrapped_send_frame:
+            self.conn.nack(ack_id, requeue="false")
+            expected_headers = {HDR_ID: ack_id, "requeue": "false"}
+            wrapped_send_frame.assert_called_with(CMD_NACK, expected_headers)
 
     def test_timeout(self):
         server = TestStompServer('127.0.0.1', 60000)


### PR DESCRIPTION
RabbitMQ requires an additional header in order to not requeue the message, as [the standard behavior is to always requeue](https://www.rabbitmq.com/stomp.html#ack-nack). `stomp.py` as it's implemented currently doesn't allow additional headers.

I use [django-stomp](https://github.com/juntossomosmais/django-stomp/) in all of our services with ActiveMQ and I've been updating it to support RabbitMQ as well, and as it requires this additional header, I did the following as a workaround:

https://github.com/juntossomosmais/django-stomp/pull/5/files#diff-f674a05647137175da86369a875175d1R58-R69

This PR solves it.