### PR TITLE
Added Python 3.4 minimum requirement to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ setup(
             'stomp = stomp.__main__:main',
         ],
     },
+    python_requires='>=3.4',
     classifiers=[
          'Development Status :: 5 - Production/Stable',
          'Intended Audience :: Developers',


### PR DESCRIPTION
This PR solves issue #279. For details, see the commit message. Ready for review and merge. Pay attention to the proposed minimum Python version of 3.4.
