### PR TITLE
Picked up double-disconnect notification fix from PR #266

### DIFF
--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -129,7 +129,8 @@ class StompConnection10(BaseConnection, Protocol10):
         :param keyword_headers: any additional headers to send with the disconnection
         """
         Protocol10.disconnect(self, receipt, headers, **keyword_headers)
-        self.transport.stop()
+        if receipt is not None:
+            self.transport.stop()
 
 
 class StompConnection11(BaseConnection, Protocol11):
@@ -182,7 +183,8 @@ class StompConnection11(BaseConnection, Protocol11):
         :param keyword_headers: any additional headers to send with the disconnection
         """
         Protocol11.disconnect(self, receipt, headers, **keyword_headers)
-        self.transport.stop()
+        if receipt is not None:
+            self.transport.stop()
 
 
 class StompConnection12(BaseConnection, Protocol12):
@@ -235,4 +237,5 @@ class StompConnection12(BaseConnection, Protocol12):
         :param keyword_headers: any additional headers to send with the disconnection
         """
         Protocol12.disconnect(self, receipt, headers, **keyword_headers)
-        self.transport.stop()
+        if receipt is not None:
+            self.transport.stop()

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -74,6 +74,7 @@ class BaseTransport(stomp.listener.Publisher):
 
         # flag used when we receive the disconnect receipt
         self.__disconnect_receipt = None
+        self.__notified_on_disconnect = False
 
         # function for creating threads used by the connection
         self.create_thread_fc = utils.default_create_thread
@@ -220,6 +221,7 @@ class BaseTransport(stomp.listener.Publisher):
             self.set_connected(True)
 
         elif frame_type == 'disconnected':
+            self.__notified_on_disconnect = True
             self.set_connected(False)
 
         with self.__listeners_change_condition:


### PR DESCRIPTION
Details:

* This change picks up the relevant fix code from commit 3ceb127 of PR #266
  (which is a very large PR with 66 commits) to fix an issue with double
  disconnect notification. Originally reported as issue #245.

Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>