### PR TITLE
Remove traceback print_stack debugging

### DIFF
--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -347,8 +347,6 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         :param keyword_headers: any additional headers the broker requires
         """
         if not self.transport.is_connected():
-            import traceback
-            traceback.print_stack()
             logging.debug("Not sending disconnect, already disconnected")
             return
         headers = utils.merge_headers([headers, keyword_headers])


### PR DESCRIPTION
Removed the traceback.print_stack() and import context -

```python
if not self.transport.is_connected():
    import traceback
    traceback.print_stack()
    logging.debug("Not sending disconnect, already disconnected")
    return
```