### PR TITLE
fix: Reconnect failure

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -360,6 +360,7 @@ class BaseTransport(stomp.listener.Publisher):
                 self.notify("disconnected")
             with self.__connect_wait_condition:
                 self.__connect_wait_condition.notifyAll()
+            self.__notified_on_disconnect = False
 
     def __read(self):
         """


### PR DESCRIPTION
The "notified on disconnect" flag prevents double disconnects but once
it is set it is not being reset. So it does prevent double disconnect
event on first disconnect but on second disconnect it doesn't fire
"disconnected" event at all. This fix resets the "notified on
disconnect" flag before attempting new connection.

closes issue #294