### PR TITLE
fix: Allow \r\n heartbeats

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -382,7 +382,7 @@ class BaseTransport(stomp.listener.Publisher):
             if c is None or len(c) == 0:
                 logging.debug("nothing received, raising CCE")
                 raise exception.ConnectionClosedException()
-            if c == b'\x0a' and not self.__recvbuf and not fastbuf.tell():
+            if c in (b'\x0a', b'\x0d\x0a') and not self.__recvbuf and not fastbuf.tell():
                 #
                 # EOL to an empty receive buffer: treat as heartbeat.
                 # Note that this may misdetect an optional EOL at end of frame as heartbeat in case the

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -188,7 +188,7 @@ def parse_frame(frame):
     :rtype: Frame
     """
     f = Frame()
-    if frame == b'\x0a':
+    if frame in (b'\x0a', b'\x0d\x0a'):
         f.cmd = "heartbeat"
         return f
 


### PR DESCRIPTION
Currently only '\n' is considered a heartbeat. STOMP protocol requires
EOL as a heartbeat and EOL can be \r\n.