### PR TITLE
Remove heartbeat loop sleep

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -163,7 +163,6 @@ class HeartbeatListener(ConnectionListener):
         self.next_outbound_heartbeat = None
         self.heart_beat_receive_scale = heart_beat_receive_scale
         self.heartbeat_terminate_event = threading.Event()
-        self.loop_sleep = 1
 
     def on_connected(self, headers, body):
         """
@@ -185,9 +184,7 @@ class HeartbeatListener(ConnectionListener):
                 # set a different heart-beat-receive-scale when creating the connection to override that
                 self.receive_sleep = (self.heartbeats[1] / 1000) * self.heart_beat_receive_scale
 
-                self.loop_sleep = max(1, int(min(self.send_sleep, self.receive_sleep) / 2.0))
-
-                logging.debug("Set receive_sleep to %s, send_sleep to %s, loop sleep to %s", self.receive_sleep, self.send_sleep, self.loop_sleep)
+                logging.debug("Set receive_sleep to %s, send_sleep to %s", self.receive_sleep, self.send_sleep)
 
                 # Give grace of receiving the first heartbeat
                 self.received_heartbeat = monotonic() + self.receive_sleep
@@ -308,8 +305,6 @@ class HeartbeatListener(ConnectionListener):
                     self.transport.stop()
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
-
-            time.sleep(self.loop_sleep)
         self.heartbeat_thread = None
         self.heartbeat_terminate_event.clear()
         if self.heartbeats != (0, 0):


### PR DESCRIPTION
Heartbeat loop sleep breaks heartbeat exchange and should be
removed. There is implicit sleep in heartbeat_terminate_event.wait
which is enough.

Should fix issue #297 