### PR TITLE
Original headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * Add support for \r\n EOL handling (as per [stomp protocol v1.2](http://stomp.github.io/stomp-specification-1.2.html#Augmented_BNF))
  * Remove heartbeat loop sleep (issue https://github.com/jasonrbriggs/stomp.py/issues/297, https://github.com/jasonrbriggs/stomp.py/pull/298)
  * Update version number using the makefile and the poetry version command
+ * Add `original_headers` access to the Frame so that you can get the original value of a header even if a listener modifies it (issue https://github.com/jasonrbriggs/stomp.py/issues/300, PR https://github.com/jasonrbriggs/stomp.py/pull/309)
 
 
 ## Version 6.0.0 - Feb 2020

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,6 @@ run-docker:
 remove-docker:
 	docker stop stomppy
 	docker rm stomppy
+
+
+docker: remove-docker docker-image run-docker

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ The current version of stomp.py supports:
 
 There is also legacy 3.1.7 version using the old 3-series code (see `3.1.7 on PyPi`_ and `3.1.7 on GitHub`_). This is no longer supported, but (at least as of 2018) there were still a couple of reports of this version still being used in the wild.
 
-Note: stomp.py now follows [semantic versioning](https://semver.org/):
+Note: stomp.py now follows `semantic versioning`_:
 
 - MAJOR version for incompatible API changes,
 - MINOR version for functionality added in a backwards compatible manner, and
@@ -105,3 +105,5 @@ For testing locally, you'll need to install docker. Once installed:
 .. _`stompserver`: http://stompserver.rubyforge.org
 
 .. _`buy me a coffee`: https://www.paypal.me/jasonrbriggs
+
+.. _`semantic versioning`: https://semver.org/

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,13 @@ The current version of stomp.py supports:
 
 There is also legacy 3.1.7 version using the old 3-series code (see `3.1.7 on PyPi`_ and `3.1.7 on GitHub`_). This is no longer supported, but (at least as of 2018) there were still a couple of reports of this version still being used in the wild.
 
+Note: stomp.py now follows [semantic versioning](https://semver.org/):
+
+- MAJOR version for incompatible API changes,
+- MINOR version for functionality added in a backwards compatible manner, and
+- PATCH version for backwards compatible bug fixes.
+
+
 
 Testing
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stomp.py"
-version = "6.1.0"
+version = "7.0.0"
 description = "Python STOMP client, supporting versions 1.0, 1.1 and 1.2 of the protocol"
 authors = ["Jason R Briggs <jasonrbriggs@gmail.com>"]
 license = "Apache-2.0"

--- a/stomp/__main__.py
+++ b/stomp/__main__.py
@@ -164,9 +164,7 @@ class StompCLI(Cmd, ConnectionListener):
             with open(fname, 'wb') as f:
                 f.write(content)
             frame.body = "Saved file: %s" % fname
-            self.__print_async("MESSAGE", frame)
-        else:
-            self.__print_async("MESSAGE", frame)
+        self.__print_async("MESSAGE", frame)
 
     def on_error(self, frame):
         """

--- a/stomp/adapter/multicast.py
+++ b/stomp/adapter/multicast.py
@@ -76,7 +76,7 @@ class MulticastTransport(Transport):
             if frame_type == "message":
                 if f.headers["destination"] not in self.subscriptions.values():
                     return
-                (f.headers, f.body) = self.notify("before_message", f)
+                self.notify("before_message", f)
             self.notify(frame_type, f)
         if "receipt" in f.headers:
             receipt_frame = Frame("RECEIPT", {"receipt-id": f.headers["receipt"]})
@@ -148,7 +148,7 @@ class MulticastConnection(BaseConnection, Protocol12):
         """
         if headers is None:
             headers = {}
-        frame = utils.Frame(cmd, headers, body)
+        frame = Frame(cmd, headers, body)
 
         if cmd == CMD_BEGIN:
             trans = headers[HDR_TRANSACTION]

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -73,7 +73,6 @@ class ConnectionListener(object):
         :param dict headers: a dictionary containing all headers sent by the server as key/value pairs.
         :param body: the frame's payload. This is usually empty for CONNECTED frames.
         """
-        pass
 
     def on_disconnected(self):
         """
@@ -98,7 +97,7 @@ class ConnectionListener(object):
         :param dict headers: the message headers
         :param body: the message body
         """
-        return frame.headers, frame.body
+        pass
 
     def on_message(self, frame):
         """
@@ -487,7 +486,6 @@ class PrintingListener(ConnectionListener):
         :param body:
         """
         self.__print("on_before_message %s %s", frame.headers, frame.body)
-        return frame.headers, frame.body
 
     def on_message(self, frame):
         """
@@ -552,7 +550,6 @@ class TestListener(StatsListener, WaitingListener, PrintingListener):
             while not self.heartbeat_received:
                 self.heartbeat_condition.wait()
             self.heartbeat_received = False
-
 
     def on_connecting(self, host_and_port):
         StatsListener.on_connecting(self, host_and_port)

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -243,7 +243,7 @@ class BaseTransport(stomp.listener.Publisher):
                     self.connection_error = True
                     self.__connect_wait_condition.notify()
 
-            rtn = notify_func(headers, body)
+            rtn = notify_func(frame)
             if rtn:
                 (headers, body) = rtn
         return (headers, body)

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -180,16 +180,16 @@ class BaseTransport(stomp.listener.Publisher):
         frame_type = f.cmd.lower()
         if frame_type in ["connected", "message", "receipt", "error", "heartbeat"]:
             if frame_type == "message":
-                (f.headers, f.body) = self.notify("before_message", f.headers, f.body)
+                (f.headers, f.body) = self.notify("before_message", f)
             if logging.isEnabledFor(logging.DEBUG):
                 logging.debug("Received frame: %r, headers=%r, body=%r", f.cmd, f.headers, f.body)
             else:
                 logging.info("Received frame: %r, len(body)=%r", f.cmd, length(f.body))
-            self.notify(frame_type, f.headers, f.body)
+            self.notify(frame_type, f)
         else:
             logging.warning("Unknown response frame type: '%s' (frame length was %d)", frame_type, length(frame_str))
 
-    def notify(self, frame_type, headers=None, body=None):
+    def notify(self, frame_type, frame=None):
         """
         Utility function for notifying listeners of incoming and outgoing messages
 
@@ -197,6 +197,10 @@ class BaseTransport(stomp.listener.Publisher):
         :param dict headers: the map of headers associated with the message
         :param body: the content of the message
         """
+        headers, body = (None, None)
+        if frame is not None:
+            headers, body = (frame.headers, frame.body)
+
         if frame_type == "receipt":
             # logic for wait-on-receipt notification
             receipt = headers["receipt-id"]

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -2,6 +2,7 @@
 """
 
 import copy
+import logging
 import os
 import re
 import socket
@@ -190,7 +191,6 @@ def parse_frame(frame):
 
     :rtype: Frame
     """
-    f = Frame()
     mat = PREAMBLE_END_RE.search(frame)
     if mat:
         preamble_end = mat.start()
@@ -201,7 +201,7 @@ def parse_frame(frame):
     preamble = decode(frame[0:preamble_end])
     preamble_lines = LINE_END_RE.split(preamble)
     preamble_len = len(preamble_lines)
-    f.body = frame[body_start:]
+    body = frame[body_start:]
 
     # Skip any leading newlines
     first_line = 0
@@ -212,12 +212,12 @@ def parse_frame(frame):
         return None
 
     # Extract frame type/command
-    f.cmd = preamble_lines[first_line]
+    cmd = preamble_lines[first_line]
 
     # Put headers into a key/value map
-    f.headers = parse_headers(preamble_lines, first_line + 1)
+    headers = parse_headers(preamble_lines, first_line + 1)
 
-    return f
+    return Frame(cmd, headers, body)
 
 
 def merge_headers(header_map_list):
@@ -326,9 +326,10 @@ class Frame(object):
     :param dict headers: a map of headers for the frame
     :param body: the content of the frame.
     """
-    def __init__(self, cmd=None, headers=None, body=None):
+    def __init__(self, cmd, headers=None, body=None):
         self.cmd = cmd
         self.headers = headers if headers is not None else {}
+        self.original_headers = copy.copy(self.headers)
         self.body = body
 
     def __str__(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,8 +76,8 @@ class TestUtils(object):
             assert str(f) == str(Frame("MESSAGE", {"content-type": "text/plain"}, b"hello world!"))
 
     def test_clean_default_headers(self):
-        Frame().headers["foo"] = "bar"
-        assert Frame().headers == {}
+        Frame('test').headers["foo"] = "bar"
+        assert Frame('test').headers == {}
 
     def test_join(self):
         str = stomp.utils.join((b'a', b'b', b'c'))


### PR DESCRIPTION
Provides the ability to get the original headers of a message (so if the headers are modified by a listener, you can always refer back to the original).  Fix for https://github.com/jasonrbriggs/stomp.py/issues/300