### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -49,7 +49,7 @@ class TestThreading(object):
         for i in range(0, self.clients):
             t = threading.Thread(name="client %s" % i,
                                  target=self.make_sender(i))
-            t.setDaemon(1)
+            t.daemon = True
             self.threads.append(t)
 
     def shutdown(self):


### PR DESCRIPTION
Fixes #360 