### PR TITLE
fix: ValueError in listener (#219)

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -239,9 +239,8 @@ class HeartbeatListener(ConnectionListener):
 
         :param Frame frame: the Frame object
         """
-        if frame.cmd == CMD_CONNECT or frame.cmd == CMD_STOMP:
-            if self.heartbeats != (0, 0):
-                frame.headers[HDR_HEARTBEAT] = "%s,%s" % self.heartbeats
+        if frame.cmd in [CMD_CONNECT, CMD_STOMP] and self.heartbeats != (0, 0):
+            frame.headers[HDR_HEARTBEAT] = "%s,%s" % self.heartbeats
         if self.next_outbound_heartbeat is not None:
             self.next_outbound_heartbeat = monotonic() + self.send_sleep
 

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -275,7 +275,7 @@ class HeartbeatListener(ConnectionListener):
                 t = self.received_heartbeat + self.receive_sleep - now
                 if t > 0:
                     next_events.append(t)
-            sleep_time = min(next_events)
+            sleep_time = min(next_events) if next_events else 0
             if sleep_time > 0:
                 terminate = self.heartbeat_terminate_event.wait(sleep_time)
                 if terminate:


### PR DESCRIPTION
#219 describes a `ValueError` in `listener.py` under certain circumstances that lead to an empty `next_events` array. I haven't found the cause of the issue yet, but this change should at least prevent the error itself from happening. What this means downstream, I don't know yet. So take this PR with a grain of salt. 

It also contains a small refactoring that Sourcery AI suggested. My Python foo tells me, it should be fine. 