### PR TITLE
test_misc.py: shutdown the heartbeat thread so it doesn't go into a busy loop

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -168,6 +168,8 @@ class TestMiscellaneousLogic(object):
 
         # just check if there was a received heartbeat calculated
         assert hl.received_heartbeat > 0
+        # Shut down the heartbeat thread so it doesn't go into a busy loop
+        hl.on_disconnected()
 
     def test_original_headers(self, conn2):
         listener = conn2.get_listener("testlistener")


### PR DESCRIPTION
`HeartbeatListener` relies on the transport to call its `on_send()` method to update
`received_heartbeat`, so it knows how long to wait before sending the next heartbeat.
`test_heartbeatlistener()` mocks the transport, resulting in the callback never happening.
When running the full test suite, after `receive_sleep` has elapsed, the heartbeat thread
goes into a busy loop sending heartbeat frames and spamming the log. Explicitly shut down
the heartbeat thread using `HeartbeatListener.on_disconnected()` to avoid this.