### PR TITLE
mock dns responses to make running tests easier and more efficient

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,10 +67,6 @@ stomp.py has been perfunctorily tested on:
 
 For testing locally, you'll need to install docker. Once installed:
 
-#. Add test domain names to your hosts file like so: 
-      |  172.17.0.2  my.example.com
-      |  172.17.0.2  my.example.org
-      |  172.17.0.2  my.example.net
 #. Install dependencies:
         poetry install
 #. Install optional dependencies (if testing with ssl)
@@ -83,6 +79,11 @@ For testing locally, you'll need to install docker. Once installed:
         make test
 #. Cleanup the container afterwards if you don't need it any more:
         make remove-docker
+
+If you want to connect to the test services locally (other than from the included tests), you'll want to add test domain names to your hosts file like so:
+      |  172.17.0.2  my.example.com
+      |  172.17.0.2  my.example.org
+      |  172.17.0.2  my.example.net
 
 
 .. _`STOMP`: http://stomp.github.io

--- a/tests/test_ss.py
+++ b/tests/test_ss.py
@@ -25,7 +25,7 @@ heart-beat:1000,1000
         conn = stomp.Connection([("192.0.2.0", 10000), ("127.0.0.1", 60000)], timeout=1, prefer_localhost=False)
         listener = TestListener(print_to_log=True)
         conn.set_listener('', listener)
-        conn.connect()
+        conn.connect(wait=True)
 
     def test_disconnect(self, server):
         server.add_frame('''CONNECTED

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -159,7 +159,7 @@ class StubStompServer(object):
             del self.frames[0]
             return rtn
         else:
-            return ''
+            return None
 
     def add_frame(self, frame):
         self.frames.append(frame)


### PR DESCRIPTION
By monkeypatching `socket.getaddrinfo()` in a couple of places, the requirement to add
entries to the hosts file (which usually requires root access) is removed. It also
avoid long timeouts in dual-stack IPv4/IPv6 environments where the tests try to connect
to the IPv6 address for localhost first, but the test service is only listening on the
IPv4 address.

Also update `test_alternate_hosts()` to wait for a successful connection, and fix a
logic error in `StubStompServer` where `get_next_frame()` was returning an empty string but the
caller was testing for `None`.