### PR TITLE
enable testing with podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ podman-image: docker/tmp/activemq-artemis-bin.tar.gz ssl-setup
 
 
 run-podman:
-	podman network create --subnet 172.17.0.0/24 --ipv6 stomptest
+	podman network create --ipv6 --subnet 172.17.0.0/24 --subnet fddf:aaaa:bbbb:cccc::/64 stomptest
 	podman run --network stomptest:ip=172.17.0.2 --add-host="my.example.com:127.0.0.1" --add-host="my.example.org:127.0.0.1" --add-host="my.example.net:127.0.0.1" -d -p 61613:61613 -p 62613:62613 -p 62614:62614 -p 63613:63613 -p 64613:64613 --name stomppy -it stomppy
 	podman ps
 	podman exec -it stomppy /bin/sh -c "/etc/init.d/activemq start"

--- a/README.rst
+++ b/README.rst
@@ -65,23 +65,29 @@ stomp.py has been perfunctorily tested on:
 - Apache ActiveMQ `Artemis`_  (`test_artemis.py <https://github.com/jasonrbriggs/stomp.py/blob/dev/tests/test_artemis.py>`_)
 - `stompserver`_  (`test_stompserver.py <https://github.com/jasonrbriggs/stomp.py/blob/dev/tests/test_stompserver.py>`_)
 
-For testing locally, you'll need to install docker. Once installed:
+For testing locally, you'll need to install docker (or `podman`_). Once installed:
 
 #. Install dependencies:
-        poetry install
-#. Create the docker image:
-        make docker-image
+        ``poetry install``
+#. Create the docker (or podman) image:
+        ``make docker-image`` (or ``make podman-image``)
 #. Run the container:
-        make run-docker
+        ``make run-docker`` (or ``make run-podman``)
 #. Run stomp.py unit tests:
-        make test
+        ``make test``
 #. Cleanup the container afterwards if you don't need it any more:
-        make remove-docker
+        ``make remove-docker`` (or ``make remove-podman``)
 
 If you want to connect to the test services locally (other than from the included tests), you'll want to add test domain names to your hosts file like so:
       |  172.17.0.2  my.example.com
       |  172.17.0.2  my.example.org
       |  172.17.0.2  my.example.net
+
+If you're using `podman`_ and you want to access services via their private IP addresses, you'll want to run your commands with::
+
+  podman unshare --rootless-netns <command>
+
+so that <command> has access to the private container network. Service ports are also exposed to the host and can be accessed directly.
 
 
 .. _`STOMP`: http://stomp.github.io
@@ -110,3 +116,5 @@ If you want to connect to the test services locally (other than from the include
 .. _`buy me a coffee`: https://www.paypal.me/jasonrbriggs
 
 .. _`semantic versioning`: https://semver.org/
+
+.. _`podman`: https://podman.io/

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -2,6 +2,7 @@
 
 from configparser import RawConfigParser
 import json
+import os
 import sys
 import time
 from subprocess import run, PIPE
@@ -53,6 +54,10 @@ def get_default_password():
 def get_ipv6_host():
     if config.has_option("ipv6", "host"):
         host = config.get("ipv6", "host")
+    elif os.environ.get('CONTAINERS_RUNROOT'):
+        # Running under "podman unshare"
+        result = run(["podman", "inspect", "stomppy", "-f", "{{.NetworkSettings.Networks.stomptest.GlobalIPv6Address}}"], stdout=PIPE)
+        host = result.stdout.decode("utf-8").strip()
     else:
         result = run(["docker", "ps", "-f", "name=stomppy", "--format", "{{.ID}}"], stdout=PIPE)
         container_id = result.stdout.decode("utf-8").rstrip()


### PR DESCRIPTION
`podman` allows containers to be run by non-root users, and requires no special privileges or
background daemons. It is available natively on most modern Linux distros, as well as
on Windows and MacOS. Enabling `stomp.py` to be tested using `podman` expands the environments
where `stomp.py` development is possible.

Note that `podman` >= 4.0.0 is required (for static ip support). Tested using `podman` 4.1.0 on
Fedora 36 x86_64.