### PR TITLE
[#393] Fix race condition between ack/nack and disconnect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON_VERSION_MAJOR:=$(shell $(PYTHON) -c "import sys;print(sys.version_info[0]
 PLATFORM := $(shell uname)
 VERSION :=$(shell poetry version | sed 's/stomp.py\s*//g' | sed 's/\./, /g')
 SHELL=/bin/bash
-ARTEMIS_VERSION=2.22.0
+ARTEMIS_VERSION=2.23.1
 TEST_CMD := $(shell podman network exists stomptest &> /dev/null && echo "podman unshare --rootless-netns poetry" || echo "poetry")
 
 all: test install

--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -150,14 +150,18 @@ class StompConnection11(BaseConnection, Protocol11):
         self.transport.start()
         Protocol11.connect(self, *args, **kwargs)
 
-    def disconnect(self, receipt=None, headers=None, **keyword_headers):
+    def disconnect(self, receipt=None, headers=None, wait=False, **keyword_headers):
         """
         Call the protocol disconnection, and then stop the transport itself.
 
         :param str receipt: the receipt to use with the disconnect
         :param dict headers: a map of any additional headers to send with the disconnection
+        :param bool wait: wait for the started messages to finish ack/nack before disconnection
         :param keyword_headers: any additional headers to send with the disconnection
         """
+        if wait:
+            self.transport.begin_stop()
+
         Protocol11.disconnect(self, receipt, headers, **keyword_headers)
         if receipt is not None:
             self.transport.stop()

--- a/tests/test_disconnect_wait.py
+++ b/tests/test_disconnect_wait.py
@@ -1,0 +1,110 @@
+import logging
+
+import stomp
+from stomp.listener import TestListener
+from .testutils import *
+
+
+class BrokenConnectionListener(TestListener):
+    def __init__(self, connection=None):
+        TestListener.__init__(self)
+        self.connection = connection
+        self.messages_started = 0
+        self.messages_completed = 0
+
+    def on_error(self, frame):
+        TestListener.on_error(self, frame)
+        assert frame.body.startswith("org.apache.activemq.transport.stomp.ProtocolException: Not connected")
+
+    def on_message(self, frame):
+        TestListener.on_message(self, frame)
+        self.messages_started += 1
+
+        if self.connection.is_connected():
+            try:
+                self.connection.ack(frame.headers["message-id"], frame.headers["subscription"])
+                self.messages_completed += 1
+            except BrokenPipeError:
+                logging.error("Expected BrokenPipeError")
+                self.errors += 1
+
+
+def conn():
+    c = stomp.Connection11(get_default_host(), try_loopback_connect=False)
+    c.set_listener("testlistener", BrokenConnectionListener(c))
+    c.connect(get_default_user(), get_default_password(), wait=True)
+    return c
+
+
+def run_race_condition_situation(conn, wait):
+    # happens when using ack mode "client-individual"
+    # some load, eg > 50 messages received at same time (simulated with transaction)
+    listener = conn.get_listener("testlistener")  # type: BrokenConnectionListener
+
+    queuename = "/queue/disconnectmidack-%s" % listener.timestamp
+    conn.subscribe(destination=queuename, id=1, ack="client-individual")
+
+    trans_id = conn.begin()
+    for i in range(50):
+        conn.send(body="test message", destination=queuename, transaction=trans_id)
+    conn.commit(transaction=trans_id)
+
+    listener.wait_for_message()
+    conn.disconnect(wait=wait)
+
+    # wait for some messages to start between the time of disconnect start and finish (when the race condition happens)
+    # needed to check result of listener.errors
+    time.sleep(0.5)
+
+    # return listener for asserts
+    return listener
+
+
+def assert_race_condition_disconnect_mid_ack(conn, wait=False):
+    listener = run_race_condition_situation(conn, wait)
+
+    started = listener.messages_started
+    logging.debug("messages started %d", started)
+
+    assert listener.connections == 1, "should have received 1 connection acknowledgement"
+    assert listener.messages == started, f"should have received {started} message"
+
+    # Causes either BrokenPipeError or ProtocolException: Not connected
+    assert listener.errors >= 1, "should have at least one error"
+    assert listener.messages_started > listener.messages_completed, f"should have not completed all started"
+
+
+def assert_no_race_condition_disconnect_mid_ack(conn, wait=False):
+    listener = run_race_condition_situation(conn, wait)
+
+    started = listener.messages_started
+    logging.debug("T%s : messages started %d", started, threading.get_native_id())
+
+    assert listener.connections == 1, "should have received 1 connection acknowledgement"
+    assert listener.messages == started, f"should have received {started} message"
+
+    assert listener.errors == 0, "should not have errors"
+    assert listener.messages_started == listener.messages_completed, f"should have completed all started"
+
+
+def test_assert_race_condition_in_disconnect_mid_ack():
+    found_race_condition = False
+    retries_until_race_condition = 0
+    while not found_race_condition:
+        try:
+            assert_race_condition_disconnect_mid_ack(conn())
+            found_race_condition = True
+        except AssertionError as e:
+            retries_until_race_condition += 1
+            continue
+
+    assert found_race_condition is True
+    # might occur at first try, might take 50 retries
+    logging.warning("Tries until race condition: %d", retries_until_race_condition)
+
+
+def test_assert_fixed_race_condition_in_disconnect_mid_ack():
+    # same test case but asserts no error
+    # you can increase forever, it always passes
+    for n in range(100):
+        assert_no_race_condition_disconnect_mid_ack(conn(), wait=True)


### PR DESCRIPTION
Issue: #393 

> I identified a race condition when there's some load of processing messages and a disconnect occurs.
This issue only occurs with ack mode client/client-individual which means a ACK or NACK frame will be sent to the server.
>
> In such cases, between the milliseconds a disconnect begins and concludes, some other threads might start processing a new message and when trying to send the frame ACK/NACK will result in either a native BrokenPipeError (unhandled by stompy) or a org.apache.activemq.transport.stomp.ProtocolException: Not connected (properly handled).
>
> I'm providing a MR associated with the issue, showcasing the issue in a new test case and a solution.
For the test case I rely on repetition given that the issue is a race condition.
> 
> For the solution I suggest the addition of a wait parameter to the disconnect method, which allows instantly stop receiving and enables wait for current threads to finish already started acks/nacks before stoping executing and closing the socket.

