### PR TITLE
use the defined timeout during the websocket connection

### DIFF
--- a/stomp/adapter/ws.py
+++ b/stomp/adapter/ws.py
@@ -323,12 +323,13 @@ class WSTransport(BaseTransport):
                         scheme = "ws"
                     self.socket = websocket.create_connection(
                         f"{scheme}://{host_and_port[0]}:{host_and_port[1]}{path}",
+                        timeout=self.__timeout,
                         header=self.header,
                         sslopt=self.get_ssl()
                     )
                     logging.info("established connection to host %s, port %s", host_and_port[0], host_and_port[1])
                     break
-                except (OSError, AssertionError) as exc:
+                except (OSError, AssertionError, websocket._exceptions.WebSocketException) as exc:
                     self.socket = None
                     connect_count += 1
                     logging.warning("Could not connect to host %s, port %s: %s", host_and_port[0], host_and_port[1],


### PR DESCRIPTION
Added `timeout` argument when creating WebSocket connection (similar to calling `socket.create_connection` in `stomp.transport.Transport`). In case of connection error, an exception of type `websocket._exceptions.WebSocketException` is raised (added to the except clause).