### PR TITLE
host header - Fixed support for STOMP protocol versions 1.1

### DIFF
--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -326,6 +326,8 @@ class Protocol11(HeartbeatListener, ConnectionListener):
 
         if self.transport.vhost:
             headers[HDR_HOST] = self.transport.vhost
+        else:
+            headers[HDR_HOST] = "/"
 
         if username is not None:
             headers[HDR_LOGIN] = username
@@ -516,6 +518,8 @@ class Protocol12(Protocol11):
 
         if self.transport.vhost:
             headers[HDR_HOST] = self.transport.vhost
+        else:
+            headers[HDR_HOST] = "/"
 
         if username is not None:
             headers[HDR_LOGIN] = username

--- a/stomp/protocol.py
+++ b/stomp/protocol.py
@@ -323,11 +323,10 @@ class Protocol11(HeartbeatListener, ConnectionListener):
         cmd = CMD_CONNECT if with_connect_command else CMD_STOMP
         headers = utils.merge_headers([headers, keyword_headers])
         headers[HDR_ACCEPT_VERSION] = self.version
+        headers[HDR_HOST] = self.transport.current_host_and_port[0]
 
         if self.transport.vhost:
             headers[HDR_HOST] = self.transport.vhost
-        else:
-            headers[HDR_HOST] = "/"
 
         if username is not None:
             headers[HDR_LOGIN] = username
@@ -518,8 +517,6 @@ class Protocol12(Protocol11):
 
         if self.transport.vhost:
             headers[HDR_HOST] = self.transport.vhost
-        else:
-            headers[HDR_HOST] = "/"
 
         if username is not None:
             headers[HDR_LOGIN] = username


### PR DESCRIPTION
[EDITED]

Hi, if the ```vhost``` option is not specified in ```stomp.py```, the ```STOMP``` command (```CONNECT```) has unexpected behavior for STOMP versions 1.1.

## STOMP 1.1 frame:
if ```vhost``` option is not specified and the selected STOMP version is 1.1, ```stomp.py``` will send a ```STOMP``` command without ```host``` header.

```
STOMP
accept-version:1.1
login:user
passcode:password

.
```

---

Ss per the STOMP protocol specification, the ```host``` header MUST be set:

```
[...]
STOMP 1.{1,2} clients MUST set the following headers:

    accept-version : The versions of the STOMP protocol the client supports. 
    See [Protocol Negotiation](https://stomp.github.io/stomp-specification-1.1.html#Protocol_Negotiation) for more details.

    host : The name of a virtual host that the client wishes to connect to. It is recommended clients set this to the host name that the 
    socket was established against, or to any name of their choosing. If this header does not match a known virtual host, servers 
    supporting virtual hosting MAY select a default virtual host or reject the connection.
[...]
```

I tried to fix this protocol compatibility for versions 1.1 by setting the ```host``` header with ```self.transport.current_host_and_port[0] ``` , same as protocol version 1.2.

In addition, the CLI also needs to add an argument to pass the ```host``` header via the command line (working on it) and maybe the code related to the header set block could be changed to a method shared betwen classes to avoid code repetition (?).

Am I wrong with this patch?

## Reproduce

Run a simple ```tcpdump``` as following:

```
 tcpdump -An port 61613 and proto 6
```

Then run the following script:

```
import sys
import stomp

stomp.logging.verbose = True
conn = stomp.Connection11([("10.1.0.14", 61613)])
conn.connect('user', 'password', wait=True)
conn.send(body=' '.join(sys.argv[1:]), destination='/queue/test')
conn.disconnect()
```

or the following commands:

```
stomp -H 10.1.0.14 -P 61613 -U user -W password -V -S 1.1
```