### PR TITLE
fix: correct WSTransport.receive output

### DIFF
--- a/stomp/adapter/ws.py
+++ b/stomp/adapter/ws.py
@@ -212,7 +212,8 @@ class WSTransport(BaseTransport):
         :rtype: bytes
         """
         try:
-            return self.socket.recv().encode()
+            ret = self.socket.recv()
+            return ret.encode() if type(ret) == str else ret
         except socket.error:
             _, e, _ = sys.exc_info()
             if get_errno(e) in (errno.EAGAIN, errno.EINTR):


### PR DESCRIPTION
Hi there!

I was trying this out and eventually found this bug - I get an `AttributeError: 'bytes' object has no attribute 'encode'`. I think this is because `self.socket.recv()` returns [either bytes or str](https://github.com/websocket-client/websocket-client/blob/master/websocket/_core.py#L362#L368), so this PR just handles the case where a string is returned and encodes to bytes - it seems like that's how you wanted this function to behave.

Let me know if I've missed anything - thanks!