### PR TITLE
Update pyproject.toml - use poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ stomp = "stomp.__main__:main"
 [tool.poetry_bumpversion.file."stomp/__init__.py"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
```
 × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> [1 lines of output]
        ERROR: Can not execute `setup.py` since setuptools is not available in the build environment.
        [end of output]
```

Migrate to poetry-core for build-system, which does not produce the above error on an editable install `pip install -e`.