### PR TITLE
Use heartbeat_terminate_event as heartbeat loop exit condition to avoid a race condition

### DIFF
--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -264,7 +264,7 @@ class HeartbeatListener(ConnectionListener):
             self.next_outbound_heartbeat = now + self.send_sleep
             logging.debug("calculated next outbound heartbeat as %s", self.next_outbound_heartbeat)
 
-        while self.running:
+        while not self.heartbeat_terminate_event.is_set():
             now = monotonic()
 
             next_events = []

--- a/stomp/listener.py
+++ b/stomp/listener.py
@@ -193,6 +193,7 @@ class HeartbeatListener(ConnectionListener):
 
                 self.running = True
                 if self.heartbeat_thread is None:
+                    self.heartbeat_terminate_event.clear()
                     self.heartbeat_thread = utils.default_create_thread(
                         self.__heartbeat_loop)
                     self.heartbeat_thread.name = "StompHeartbeat%s" % \
@@ -309,7 +310,6 @@ class HeartbeatListener(ConnectionListener):
                     for listener in self.transport.listeners.values():
                         listener.on_heartbeat_timeout()
         self.heartbeat_thread = None
-        self.heartbeat_terminate_event.clear()
         if self.heartbeats != (0, 0):
             # don't bother logging this if heartbeats weren't setup to start with
             logging.debug("heartbeat loop ended")


### PR DESCRIPTION
What can happen (and really does happen) without this small change is that:
- `HeartbeatListener.on_disconnected` is called;
- `self.running` is set to `False`;
- there is a switch to the heartbeat thread;
- `self.running` is evaluated and the while loop of `HeartbeatListener.__heartbeat_loop` exits;
- `self.heartbeat_terminate_event.clear()` is called;
- there is a switch to the previous thread;
- `self.heartbeat_terminate_event.set()` is called.

In this way on the next connection `heartbeat_terminate_event` will already be set and at the first opportunity the `break` on line 281 will be called interrupting the sending of heartbeats. When the server forces the disconnection, `on_disconnected` will be called setting `heartbeat_terminate_event` again. This recreates the previous situation where the sending of heatbeats is immediately stopped.