### PR TITLE
Make the receiver thread part of the transport class

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -73,6 +73,7 @@ class BaseTransport(stomp.listener.Publisher):
 
         # function for creating threads used by the connection
         self.create_thread_fc = default_create_thread
+        self.receiver_thread = None
 
         self.__listeners_change_condition = threading.Condition()
         self.__receiver_thread_exit_condition = threading.Condition()
@@ -106,8 +107,8 @@ class BaseTransport(stomp.listener.Publisher):
         """
         self.running = True
         self.attempt_connection()
-        receiver_thread = self.create_thread_fc(self.__receiver_loop)
-        logging.debug("created thread %s using func %s", receiver_thread, self.create_thread_fc)
+        self.receiver_thread = self.create_thread_fc(self.__receiver_loop)
+        logging.debug("created thread %s using func %s", self.receiver_thread, self.create_thread_fc)
         self.notify("connecting")
 
     def stop(self):


### PR DESCRIPTION
In some applications, the main thread has no work to do after the connection is initiated. This can lead to a while loop such as,

```python
from stomp import *
c = Connection([('127.0.0.1', 62613)])
c.set_listener('', PrintingListener())
c.connect('admin', 'password', wait=True)
c.subscribe('/queue/test', 123)
while True:
    pass
```

which is inefficient. If the thread is part of the transport class, the following can be written instead,

```python
from stomp import *
c = Connection([('127.0.0.1', 62613)])
c.set_listener('', PrintingListener())
c.connect('admin', 'password', wait=True)
c.subscribe('/queue/test', 123)
c.transport.receiver_thread.join()
```