### PR TITLE
Fix issue where non-default ssl_protocol version isn't used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON_VERSION_MAJOR:=$(shell $(PYTHON) -c "import sys;print(sys.version_info[0]
 PLATFORM := $(shell uname)
 VERSION :=$(shell poetry version | sed 's/stomp.py\s*//g' | sed 's/\./, /g')
 SHELL=/bin/bash
-ARTEMIS_VERSION=2.26.0
+ARTEMIS_VERSION=2.38.0
 TEST_CMD := $(shell podman network exists stomptest &> /dev/null && echo "podman unshare --rootless-netns poetry" || echo "poetry")
 
 all: test install

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -737,7 +737,7 @@ class Transport(BaseTransport):
 
                     if need_ssl:  # wrap socket
                         ssl_params = self.get_ssl(host_and_port)
-                        tls_context = ssl.SSLContext(DEFAULT_SSL_VERSION)
+                        tls_context = ssl.SSLContext(ssl_params["ssl_version"])
                         if ssl_params["ca_certs"]:
                             cert_validation = ssl.CERT_REQUIRED
                             tls_context.load_verify_locations(ssl_params["ca_certs"])

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -117,6 +117,30 @@ class TestSSL(object):
         except ImportError:
             pass
 
+    def test_ssl_connection_non_default_ssl_version(self):
+        """
+        Tests that when setting the ssl_version in the ssl config, this option
+        makes it all the way to the initialized ssl configuration on the socket
+        """
+        listener = TestListener("123", print_to_log=True)
+        try:
+            import ssl
+            conn = stomp.Connection(get_ssl_host())
+
+            # Ensure that we set a non-default ssl version
+            ssl_config = get_ssl_host()
+            assert len(ssl_config) == 1
+            if stomp.transport.DEFAULT_SSL_VERSION != ssl.PROTOCOL_TLSv1_2:
+                ssl_version = ssl.PROTOCOL_TLSv1_2
+            else:
+                ssl_version = ssl.PROTOCOL_TLSv1_1
+            conn.set_ssl(get_ssl_host(), ssl_version=ssl_version)
+            conn.set_listener("testlistener", listener)
+            conn.connect(get_default_user(), get_default_password(), wait=True)
+            assert conn.transport.socket._sslobj.context.protocol == ssl_version
+        except ImportError:
+            pass
+
 class TestSSLParams(object):
     def test_set_ssl(self, stomp_transport):
         stomp_transport.set_ssl([host1],


### PR DESCRIPTION
Previously, the default ssl_protocol was always used, which wasn't ideal when you have specific protocol requirements.

The test digs into the internals, but I don't see another way to determine what protocol is used.

Note that the PR also bumps the ActiveMQ Artemis version because 2.26.0 seemed to return a 404 from the download server.