### PR TITLE
fix version command in stomp CLI client

### DIFF
--- a/stomp/__main__.py
+++ b/stomp/__main__.py
@@ -368,7 +368,7 @@ class StompCLI(Cmd, ConnectionListener):
 
     def do_version(self, args):
         self.__sysout("%s%s [Protocol version %s]%s" %
-                      (stomp.colours.BOLD, stomp.version, self.conn.version, stomp.colours.NO_COLOUR))
+                      (stomp.colours.BOLD, stomp.__version__, self.conn.version, stomp.colours.NO_COLOUR))
     do_ver = do_version
 
     def help_version(self):


### PR DESCRIPTION
In the stomp CLi client when the `version` command is ran.  The following error happens:

```
> ver
lost connection


> Traceback (most recent call last):
  File "/CRIweb/play/venv/bin/stomp", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/CRIweb/play/venv/lib/pypy3.10/site-packages/stomp/__main__.py", line 544, in main
    st.cmdloop()
  File "/CRIweb/pypy3.10-v7.3.17-linux64/lib/pypy3.10/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
           ^^^^^^^^^^^^^^^^^
  File "/CRIweb/pypy3.10-v7.3.17-linux64/lib/pypy3.10/cmd.py", line 217, in onecmd
    return func(arg)
           ^^^^^^^^^
  File "/CRIweb/play/venv/lib/pypy3.10/site-packages/stomp/__main__.py", line 371, in do_version
    (stomp.colours.BOLD, stomp.version, self.conn.version, stomp.colours.NO_COLOUR))
                         ^^^^^^^^^^^^^
AttributeError: module 'stomp' has no attribute 'version'
```

This commit corrects `stomp.version` with `stomp.__version__`

Here's what the output looks like after this commit:
```
> version
8.2.0 [Protocol version 1.1]
```
