### PR TITLE
Added SSL error message from cert validation to log warning

### DIFF
--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -791,11 +791,11 @@ class Transport(BaseTransport):
                     self.socket = None
                     break
 
-                except (OSError, AssertionError):
+                except (OSError, AssertionError) as err:
                     self.socket = None
                     connect_count += 1
-                    logging.warning("could not connect to host %s, port %s", host_and_port[0], host_and_port[1],
-                                    exc_info=logging.verbose)
+                    logging.warning("could not connect to host %s, port %s: %s", host_and_port[0], host_and_port[1],
+                                    err, exc_info=logging.verbose)
 
             if self.socket is None:
                 sleep_duration = (min(self.__reconnect_sleep_max,


### PR DESCRIPTION
This addresses issue #448 .

Details:

* If CA certificate validation failed, the exception message was not added to the log or otherwise returned or raised. This change adds the exception message of any SSL validation errors to the warning that is logged.