### PR TITLE
Use single thread for IO when using TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release: updateversion
 
 docker/tmp/activemq-artemis-bin.tar.gz:
 	mkdir -p docker/tmp
-	wget http://www.apache.org/dist/activemq/activemq-artemis/${ARTEMIS_VERSION}/apache-artemis-${ARTEMIS_VERSION}-bin.tar.gz -O $@ || rm $@
+	wget https://archive.apache.org/dist/activemq/activemq-artemis/${ARTEMIS_VERSION}/apache-artemis-${ARTEMIS_VERSION}-bin.tar.gz -O $@ || rm $@
 
 
 ssl-setup:

--- a/stomp/__main__.py
+++ b/stomp/__main__.py
@@ -25,6 +25,7 @@ Options:
   --ssl-key-file=<key-file>    ssl key file
   --ssl-cert-file=<cert-file>  ssl cert file
   --ssl-ca-file=<ca-file>      ssl ca certs file
+  --ssl-insecure               disable cert validation
 
 """
 
@@ -67,7 +68,7 @@ class StompCLI(Cmd, ConnectionListener):
     for more information on establishing a connection to a stomp server.
     """
     def __init__(self, host="localhost", port=61613, user="", passcode="", ver="1.1", prompt="> ", verbose=True,
-                 heartbeats=(0, 0), use_ssl=False, ssl_key_file=None, ssl_cert_file=None, ssl_ca_file=None,
+                 heartbeats=(0, 0), use_ssl=False, ssl_key_file=None, ssl_cert_file=None, ssl_ca_file=None, ssl_insecure=False,
                  stdin=sys.stdin, stdout=sys.stdout):
         Cmd.__init__(self, "Tab", stdin, stdout)
         ConnectionListener.__init__(self)
@@ -88,7 +89,7 @@ class StompCLI(Cmd, ConnectionListener):
         else:
             raise RuntimeError("Unknown version")
         if use_ssl:
-            self.conn.set_ssl([(host, port)], key_file=ssl_key_file, cert_file=ssl_cert_file, ca_certs=ssl_ca_file)
+            self.conn.set_ssl([(host, port)], key_file=ssl_key_file, cert_file=ssl_cert_file, ca_certs=ssl_ca_file, verify=not ssl_insecure)
         self.conn.set_listener("", self)
         self.conn.connect(self.user, self.passcode, wait=True)
         self.transaction_id = None
@@ -520,7 +521,8 @@ def main():
                   use_ssl=arguments["--ssl"],
                   ssl_key_file=arguments["--ssl-key-file"],
                   ssl_cert_file=arguments["--ssl-cert-file"],
-                  ssl_ca_file=arguments["--ssl-ca-file"])
+                  ssl_ca_file=arguments["--ssl-ca-file"],
+                  ssl_insecure=arguments["--ssl-insecure"])
 
     if arguments["--listen"] is not None:
         st.do_subscribe(arguments["--listen"])

--- a/stomp/connect.py
+++ b/stomp/connect.py
@@ -105,6 +105,7 @@ class StompConnection10(BaseConnection, Protocol10):
     def disconnect(self, receipt=None, headers=None, **keyword_headers):
         """
         Call the protocol disconnection, and then stop the transport itself.
+        Provide a receipt in order to drain the send queue before returning.
 
         :param str receipt: the receipt to use with the disconnect
         :param dict headers: a map of any additional headers to send with the disconnection
@@ -153,6 +154,7 @@ class StompConnection11(BaseConnection, Protocol11):
     def disconnect(self, receipt=None, headers=None, **keyword_headers):
         """
         Call the protocol disconnection, and then stop the transport itself.
+        Provide a receipt in order to drain the send queue before returning.
 
         :param str receipt: the receipt to use with the disconnect
         :param dict headers: a map of any additional headers to send with the disconnection
@@ -201,6 +203,7 @@ class StompConnection12(BaseConnection, Protocol12):
     def disconnect(self, receipt=None, headers=None, **keyword_headers):
         """
         Call the protocol disconnection, and then stop the transport itself.
+        Provide a receipt in order to drain the send queue before returning.
 
         :param str receipt: the receipt to use with the disconnect
         :param dict headers: a map of any additional headers to send with the disconnection

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -739,8 +739,11 @@ class Transport(BaseTransport):
                         ssl_params = self.get_ssl(host_and_port)
                         tls_context = ssl.SSLContext(ssl_params["ssl_version"])
                         if ssl_params["ca_certs"]:
-                            cert_validation = ssl.CERT_REQUIRED
                             tls_context.load_verify_locations(ssl_params["ca_certs"])
+                        else:
+                            tls_context.load_default_certs()
+                        if ssl_params["verify"]:
+                            cert_validation = ssl.CERT_REQUIRED
                         else:
                             cert_validation = ssl.CERT_NONE
                         if tls_context:
@@ -820,7 +823,8 @@ class Transport(BaseTransport):
                 ca_certs=None,
                 cert_validator=None,
                 ssl_version=DEFAULT_SSL_VERSION,
-                password=None):
+                password=None,
+                verify=True):
         """
         Sets up SSL configuration for the given hosts. This ensures socket is wrapped in a SSL connection, raising an
         exception if the SSL module can't be found.
@@ -848,6 +852,7 @@ class Transport(BaseTransport):
                                                 cert_file=cert_file,
                                                 ca_certs=ca_certs,
                                                 cert_validator=cert_validator,
+                                                verify=verify,
                                                 ssl_version=ssl_version,
                                                 password=password)
 

--- a/stomp/transport.py
+++ b/stomp/transport.py
@@ -7,8 +7,10 @@ import math
 import random
 import sys
 import time
+import selectors
 from io import BytesIO
 from time import monotonic
+from collections import deque
 
 try:
     from socket import SOL_SOCKET, SO_KEEPALIVE, SOL_TCP, TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
@@ -60,7 +62,9 @@ class BaseTransport(stomp.listener.Publisher):
         self.__recvbuf = b""
         self.listeners = {}
         self.running = False
-        self.blocking = None
+        self.blocking = True # Flips to False for TLS connections
+        self.send_queue = None
+        self.sel = None
         self.connected = False
         self.connection_error = False
         self.disconnecting = False
@@ -73,11 +77,11 @@ class BaseTransport(stomp.listener.Publisher):
 
         # function for creating threads used by the connection
         self.create_thread_fc = default_create_thread
-        self.receiver_thread = None
+        self.io_thread = None
 
         self.__listeners_change_condition = threading.Condition()
-        self.__receiver_thread_exit_condition = threading.Condition()
-        self.__receiver_thread_exited = False
+        self.__io_thread_exit_condition = threading.Condition()
+        self.__io_thread_exited = False
         self.__send_wait_condition = threading.Condition()
         self.__connect_wait_condition = threading.Condition()
         self.__auto_decode = auto_decode
@@ -87,7 +91,7 @@ class BaseTransport(stomp.listener.Publisher):
     def override_threading(self, create_thread_fc):
         """
         Override for thread creation. Use an alternate threading library by
-        setting this to a function with a single argument (which is the receiver loop callback).
+        setting this to a function with a single argument (which is the io loop callback).
         The thread which is returned should be started (ready to run)
 
         :param function create_thread_fc: single argument function for creating a thread
@@ -107,18 +111,18 @@ class BaseTransport(stomp.listener.Publisher):
         """
         self.running = True
         self.attempt_connection()
-        self.receiver_thread = self.create_thread_fc(self.__receiver_loop)
-        logging.debug("created thread %s using func %s", self.receiver_thread, self.create_thread_fc)
+        self.io_thread = self.create_thread_fc(self.__io_loop)
+        logging.debug("created thread %s using func %s", self.io_thread, self.create_thread_fc)
         self.notify("connecting")
 
     def stop(self):
         """
         Stop the connection. Performs a clean shutdown by waiting for the
-        receiver thread to exit.
+        io thread to exit.
         """
-        with self.__receiver_thread_exit_condition:
-            while not self.__receiver_thread_exited and self.is_connected():
-                self.__receiver_thread_exit_condition.wait()
+        with self.__io_thread_exit_condition:
+            while not self.__io_thread_exited and self.is_connected():
+                self.__io_thread_exit_condition.wait()
 
     def is_connected(self):
         """
@@ -266,7 +270,12 @@ class BaseTransport(stomp.listener.Publisher):
 
         if logging.isEnabledFor(logging.DEBUG):
             logging.debug("sending frame: %s", clean_lines(lines))
-        self.send(packed_frame)
+
+        if not self.blocking:
+            # Let the io thread write to the socket
+            self.send_queue.put(packed_frame)
+        else:
+            self.send(packed_frame)
 
     def send(self, encoded_frame):
         """
@@ -318,28 +327,62 @@ class BaseTransport(stomp.listener.Publisher):
         if not self.running or not self.is_connected():
             raise exception.ConnectFailedException()
 
-    def __receiver_loop(self):
+    def __io_loop(self):
         """
-        Main loop listening for incoming data.
+        Main loop listening for incoming data. For non-blocking sockets the
+        loop is also responsible for writing to the socket.
         """
-        logging.debug("starting receiver loop (%s)", threading.current_thread())
+        logging.debug("starting io loop (%s)", threading.current_thread())
         notify_disconnected = True
+        outgoing = deque()
         try:
             while self.running:
                 try:
                     while self.running:
-                        frames = self.__read()
-
-                        for frame in frames:
-                            if self.__is_eol(frame):
-                                f = HEARTBEAT_FRAME
-                            else:
-                                f = parse_frame(frame)
-                            if f is None:
-                                continue
-                            if self.__auto_decode:
-                                f.body = decode(f.body)
-                            self.process_frame(f, frame)
+                        # Always attempt to read, even for non-blocking
+                        # sockets. The TLS socket might have pending incoming
+                        # application data even if the underlying TCP socket
+                        # has no pending data.
+                        self.__read_frames()
+                        if not self.blocking:
+                            for key, mask in self.sel.select():
+                                if key.fileobj == self.socket:
+                                    if mask & selectors.EVENT_READ:
+                                        self.__read_frames()
+                                    if mask & selectors.EVENT_WRITE:
+                                        if outgoing:
+                                            # Send the first chunk
+                                            buf = outgoing[0]
+                                            try:
+                                                # Don't use sendall(), may end
+                                                # up in socket buffer deadlock
+                                                # scenario if the server is
+                                                # blocked because the client's
+                                                # receive buffer is full  
+                                                sent = self.socket.send(buf)
+                                            except ssl.SSLWantReadError:
+                                                continue
+                                            except ssl.SSLWantWriteError:
+                                                continue
+                                            if sent < len(buf):
+                                                # Only part of the chunk was sent
+                                                outgoing[0] = buf[sent:]
+                                            else:
+                                                # Whole chunk sent
+                                                outgoing.popleft()
+                                        if not outgoing:
+                                            # Nothing more to send, stop writing
+                                            self.sel.modify(self.socket, selectors.EVENT_READ)
+                                            # Start checking the send queue again
+                                            self.sel.modify(self.send_queue, selectors.EVENT_READ)
+                                elif key.fileobj == self.send_queue and mask & selectors.EVENT_READ:
+                                    encoded_frame = self.send_queue.get()
+                                    outgoing.append(encoded_frame)
+                                    # Now we have data to write to the socket
+                                    self.sel.modify(self.socket, selectors.EVENT_READ | selectors.EVENT_WRITE)
+                                    # Stop checking the send queue in order to
+                                    # not buffer too many messages
+                                    self.sel.modify(self.send_queue, 0)
                 except exception.ConnectionClosedException:
                     if self.running:
                         #
@@ -349,19 +392,39 @@ class BaseTransport(stomp.listener.Publisher):
                         self.running = False
                         notify_disconnected = True
                     break
+                except Exception:
+                    _, e, _ = sys.exc_info()
+                    logging.warning(e)
                 finally:
                     self.cleanup()
+        except Exception:
+            _, e, _ = sys.exc_info()
+            logging.warning(e)
         finally:
-            with self.__receiver_thread_exit_condition:
-                self.__receiver_thread_exited = True
-                self.__receiver_thread_exit_condition.notify_all()
-            logging.debug("receiver loop ended")
+            with self.__io_thread_exit_condition:
+                self.__io_thread_exited = True
+                self.__io_thread_exit_condition.notify_all()
+            logging.debug("io loop ended")
             self.notify("receiver_loop_completed")
             if notify_disconnected and not self.notified_on_disconnect:
                 self.notify("disconnected")
             with self.__connect_wait_condition:
                 self.__connect_wait_condition.notify_all()
             self.notified_on_disconnect = False
+
+    def __read_frames(self):
+        frames = self.__read()
+
+        for frame in frames:
+            if self.__is_eol(frame):
+                f = HEARTBEAT_FRAME
+            else:
+                f = parse_frame(frame)
+            if f is None:
+                continue
+            if self.__auto_decode:
+                f.body = decode(f.body)
+            self.process_frame(f, frame)
 
     def __read(self):
         """
@@ -375,6 +438,10 @@ class BaseTransport(stomp.listener.Publisher):
             try:
                 try:
                     c = self.receive()
+                except ssl.SSLWantReadError:
+                    break
+                except ssl.SSLWantWriteError:
+                    break
                 except exception.InterruptedException:
                     logging.debug("socket read interrupted, restarting")
                     continue
@@ -382,6 +449,10 @@ class BaseTransport(stomp.listener.Publisher):
                 logging.debug("socket read error", exc_info=logging.verbose)
                 c = b""
             if c is None or len(c) == 0:
+                if not self.blocking:
+                    # recv() for TLS sockets can return None while the
+                    # connection is still open.
+                    break
                 logging.debug("nothing received, raising ConnectionClosedException")
                 raise exception.ConnectionClosedException()
             if self.__is_eol(c) and not self.__recvbuf and not fastbuf.tell():
@@ -502,7 +573,7 @@ class Transport(BaseTransport):
                  vhost=None,
                  auto_decode=True,
                  encoding="utf-8",
-                 recv_bytes=1024,
+                 recv_bytes=16384,
                  is_eol_fc=is_eol_default,
                  bind_host_port=None):
         BaseTransport.__init__(self, auto_decode, encoding, is_eol_fc)
@@ -577,7 +648,15 @@ class Transport(BaseTransport):
         """
         self.running = False
         if self.socket is not None:
+            if not self.blocking:
+                self.shutdown_queue()
             if self.__need_ssl():
+                # Do the SSL shutdown handshake in blocking mode
+                self.blocking = True
+                try:
+                    self.socket.setblocking(self.blocking)
+                except Exception:
+                    pass
                 #
                 # Even though we don't want to use the socket, unwrap is the only API method which does a proper SSL
                 # shutdown
@@ -646,11 +725,21 @@ class Transport(BaseTransport):
         """
         Close the socket and clear the current host and port details.
         """
+        if not self.blocking:
+            self.shutdown_queue()
         try:
             self.socket.close()
         except:
             pass  # ignore errors when attempting to close socket
         self.socket = None
+
+    def shutdown_queue(self):
+        self.blocking = True
+        self.sel.unregister(self.socket)
+        self.sel.unregister(self.send_queue)
+        self.sel = None
+        self.send_queue.shutdown()
+        self.send_queue = None
 
     def __enable_keepalive(self):
         def try_setsockopt(sock, name, fam, opt, val=None):
@@ -770,11 +859,15 @@ class Transport(BaseTransport):
                                 cert_reqs=cert_validation,
                                 ca_certs=ssl_params["ca_certs"],
                                 ssl_version=ssl_params["ssl_version"])
+                        # Handshake is done. Switch to non-blocking mode.
+                        self.send_queue = PollableQueue()
+                        self.sel = selectors.DefaultSelector()
+                        self.sel.register(self.send_queue, selectors.EVENT_READ)
+                        self.sel.register(self.socket, selectors.EVENT_READ)
+                        self.blocking = False
 
                     self.socket.settimeout(self.__timeout)
-
-                    if self.blocking is not None:
-                        self.socket.setblocking(self.blocking)
+                    self.socket.setblocking(self.blocking)
 
                     #
                     # Validate server cert

--- a/stomp/utils.py
+++ b/stomp/utils.py
@@ -4,6 +4,7 @@
 import copy
 import os
 import re
+import queue
 import socket
 import threading
 import uuid
@@ -354,3 +355,41 @@ def get_errno(e):
 
 
 HEARTBEAT_FRAME = Frame("heartbeat")
+
+
+# A selectors-friendly queue based on the post
+# https://stackoverflow.com/questions/17495877/python-how-to-wait-on-both-queue-and-a-socket-on-same-time
+# but appears to originate from "Python Cookbook: Recipes for Mastering Python 3"
+# by David Beazley and Brian K. Jones.
+class PollableQueue(queue.Queue):
+
+    def __init__(self):
+        super().__init__()
+        # Create a pair of connected sockets
+        if os.name == 'posix':
+            self._putsocket, self._getsocket = socket.socketpair()
+        else:
+            # Compatibility on non-POSIX systems
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.bind(('127.0.0.1', 0))
+            server.listen(1)
+            self._putsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._putsocket.connect(server.getsockname())
+            self._getsocket, _ = server.accept()
+            server.close()
+
+    def fileno(self):
+        return self._getsocket.fileno()
+
+    def put(self, item):
+        super().put(item)
+        # Might block if the consumer is slow
+        self._putsocket.send(b'x')
+
+    def get(self):
+        self._getsocket.recv(1)
+        return super().get()
+
+    def shutdown(self):
+        self._putsocket.close()
+        self._getsocket.close()

--- a/tests/test_cli_ssl.py
+++ b/tests/test_cli_ssl.py
@@ -15,7 +15,7 @@ class TestSSLCLI(object):
         teststdout = StubStdout(self)
         teststdout.expect("CONNECTED")
 
-        cli = StompCLI(sslhost, sslport, username, password, "1.0", use_ssl=True, stdin=teststdin, stdout=teststdout)
+        cli = StompCLI(sslhost, sslport, username, password, "1.0", use_ssl=True, ssl_insecure=True, stdin=teststdin, stdout=teststdout)
 
         time.sleep(3)
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -52,6 +52,41 @@ class TestSSL(object):
         except ImportError:
             pass
 
+
+    def test_ssl_stress(self):
+        listener = TestListener()
+        try:
+            import ssl
+            destination = "/topic/testssl-%s" % listener.timestamp
+            conn = stomp.Connection(get_ssl_host())
+            conn.set_ssl(get_ssl_host(), verify=False)
+            conn.set_listener("testlistener", listener)
+            conn.connect(get_default_user(), get_default_password(), wait=True)
+            conn.subscribe(destination=destination, id=1, ack="auto")
+
+            small = 100
+            for i in range(small):
+                conn.send(body="small message", destination=destination, receipt="small%d" % i)
+
+            large = 100
+            for i in range(small):
+                body = "large message" + "." * (64*1024)
+                conn.send(body=body, destination=destination, receipt="large%d" % i)
+
+            t0 = time.time()
+            while listener.messages < small+large:
+                time.sleep(0.5)
+                assert time.time()-t0 < 30, "timeout"
+
+            conn.disconnect(receipt="goodbye")
+
+            assert listener.connections == 1, "should have received 1 connection acknowledgement"
+            assert listener.messages == small+large, "should have received all messages"
+            assert listener.errors == 0, "should not have received any errors"
+        except ImportError:
+            pass
+
+
     def test_ssl_client_cert_connection(self):
         listener = TestListener("123", print_to_log=True)
         try:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -33,7 +33,7 @@ class TestSSL(object):
             queuename = "/queue/testssl-%s" % listener.timestamp
             conn = stomp.Connection(get_ssl_host())
             #conn.set_ssl(get_ssl_host())
-            conn.set_ssl(get_ssl_host())
+            conn.set_ssl(get_ssl_host(), verify=False)
             conn.set_listener("testlistener", listener)
             conn.connect(get_default_user(), get_default_password(), wait=True)
             conn.subscribe(destination=queuename, id=1, ack="auto")
@@ -134,7 +134,7 @@ class TestSSL(object):
                 ssl_version = ssl.PROTOCOL_TLSv1_2
             else:
                 ssl_version = ssl.PROTOCOL_TLSv1_1
-            conn.set_ssl(get_ssl_host(), ssl_version=ssl_version)
+            conn.set_ssl(get_ssl_host(), ssl_version=ssl_version, verify=False)
             conn.set_listener("testlistener", listener)
             conn.connect(get_default_user(), get_default_password(), wait=True)
             assert conn.transport.socket._sslobj.context.protocol == ssl_version

--- a/tests/test_ssl_sni.py
+++ b/tests/test_ssl_sni.py
@@ -24,7 +24,7 @@ class TestSNIMQSend(object):
             logging.info("running ipv6 test")
             receipt_id = str(uuid.uuid4())
             conn = stomp.Connection11(get_sni_ssl_host())
-            conn.set_ssl(get_sni_ssl_host())
+            conn.set_ssl(get_sni_ssl_host(), verify=False)
             listener = TestListener(receipt_id, print_to_log=True)
             conn.set_listener('', listener)
             conn.connect(get_default_user(), get_default_password(), wait=True)


### PR DESCRIPTION
Previously reads always happened in a separate thread (the "receiver thread") while writes happened in the main thread. This is fine for plain TCP sockets for the TLS the situation is less clear. Underlying `SSL_read`/`SSL_write` functions are not thread-safe however Python's `ssl` module might add some or full thread-safety. Either way, in https://github.com/jasonrbriggs/stomp.py/issues/450 two different errors where observed when connecting to a TLS server:

1. Random `ConnectFailedException`. According to debug logs, the "STOMP" message was sent but it was seemingly never received by the server  and the server eventually closed the connection.

2. Sending the "STOMP" message sometimes resulted in `ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:2427)`.

To ensure we don't run into thread-safety issues we now do both reads and writes in the same thread for TLS. Since we need to be able to receive and send messages concurrently we also switch to a non-blocking socket.

Non-TLS connections are not affected by this change, they read and write in different threads like before.